### PR TITLE
DivikResult save interface

### DIFF
--- a/src/Spectre.Algorithms.Tests/Results/DivikResultTests.cs
+++ b/src/Spectre.Algorithms.Tests/Results/DivikResultTests.cs
@@ -1,0 +1,65 @@
+﻿/*
+ * DivikResultTests.cs
+ * Tests DivikResult class.
+ * 
+   Copyright 2017 Grzegorz Mrukwa
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using Spectre.Algorithms.Methods;
+using Spectre.Algorithms.Parameterization;
+using Spectre.Algorithms.Results;
+using Spectre.Data.Datasets;
+
+namespace Spectre.Algorithms.Tests.Results
+{
+    [TestFixture, Category("Algorithm")]
+    public class DivikResultTests
+    {
+        private DivikResult _result;
+
+        private readonly string _testFilePath = TestContext.CurrentContext.TestDirectory + "\\..\\..\\..\\small-test.txt";
+
+        [OneTimeSetUp]
+        public void SetUpFixture()
+        {
+            var dataset = new BasicTextDataset(_testFilePath);
+            var options = DivikOptions.ForLevels(1);
+            options.MaxK = 2;
+            options.Caching = false;
+            options.PlottingPartitions = false;
+            options.PlottingDecomposition = false;
+            options.PlottingDecompositionRecursively = false;
+            options.PlottingRecursively = false;
+            options.UsingAmplitudeFiltration = false;
+            options.UsingVarianceFiltration = false;
+            using (var segmentation = new Segmentation())
+            {
+                _result = segmentation.Divik(dataset, options);
+            }
+        }
+
+        [Test]
+        public void Save()
+        {
+            Assert.Throws<NotImplementedException>(() => _result.Save("test-path.json"));
+        }
+    }
+}

--- a/src/Spectre.Algorithms.Tests/Spectre.Algorithms.Tests.csproj
+++ b/src/Spectre.Algorithms.Tests/Spectre.Algorithms.Tests.csproj
@@ -56,6 +56,7 @@
     <Compile Include="Methods\PreprocessingTests.cs" />
     <Compile Include="Methods\SegmentationTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Results\DivikResultTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Spectre.Algorithms\Spectre.Algorithms.csproj">

--- a/src/Spectre.Algorithms.Tests/small-test.txt
+++ b/src/Spectre.Algorithms.Tests/small-test.txt
@@ -1,0 +1,10 @@
+in this line are global metadata, which is discarded for now; next line gives us m/z axis; then spectrum metadata (X,Y,Z for now) + intensities in separate lines
+899.99 902.58 912.04
+1 1 0
+12 20 0
+2 1 0
+9 18 13
+1 2 0
+5 10 20
+2 2 0
+14 2 19

--- a/src/Spectre.Algorithms/Results/DivikResult.cs
+++ b/src/Spectre.Algorithms/Results/DivikResult.cs
@@ -18,12 +18,14 @@
 */
 
 
+using System;
+
 namespace Spectre.Algorithms.Results
 {
 	/// <summary>
 	/// Wraps DiviK algorithm results.
 	/// </summary>
-	public class DivikResult
+	public sealed class DivikResult
     {
 	    private object _matlabResultStruct;
 
@@ -34,6 +36,16 @@ namespace Spectre.Algorithms.Results
 		internal DivikResult(object[] matlabResult)
         {
 	        _matlabResultStruct = matlabResult[1];
+        }
+
+        /// <summary>
+        /// Saves result under the specified path in JSON format.
+        /// </summary>
+        /// <param name="path">The destination path.</param>
+        /// <exception cref="System.NotImplementedException">Always, as result saving has not been implemented yet.</exception>
+        public void Save(string path)
+        {
+            throw new NotImplementedException("Result saving has not been implemented yet.");
         }
     }
 }


### PR DESCRIPTION
Extends DivikResult interface through Save function without
implementation, to allow working in WPF client with full
interface available.
Makes DivikResult sealed so there is no possibility to create
an object of this class outside DiviK algorithm implementation.