### PR TITLE
Add Equal to DivikResult

### DIFF
--- a/src/Spectre.Algorithms.Tests/Results/DivikResultTests.cs
+++ b/src/Spectre.Algorithms.Tests/Results/DivikResultTests.cs
@@ -29,6 +29,7 @@ namespace Spectre.Algorithms.Tests.Results
     public class DivikResultTests
     {
         private DivikResult _result;
+        private Segmentation _segmentation;
 
         private readonly string _testFilePath = TestContext.CurrentContext.TestDirectory + "\\..\\..\\..\\small-test.txt";
 
@@ -43,16 +44,90 @@ namespace Spectre.Algorithms.Tests.Results
             options.PlottingDecomposition = false;
             options.PlottingDecompositionRecursively = false;
             options.PlottingRecursively = false;
-            using (var segmentation = new Segmentation())
-            {
-                _result = segmentation.Divik(dataset, options);
-            }
+            _segmentation = new Segmentation();
+            _result = _segmentation.Divik(dataset, options);
+        }
+
+        [OneTimeTearDown]
+        public void TearDownFixture()
+        {
+            _segmentation.Dispose();
+            _segmentation = null;
         }
 
         [Test]
         public void Save()
         {
             Assert.Throws<NotImplementedException>(() => _result.Save("test-path.json"));
+        }
+
+        [Test]
+        public void EqualsAgainstIdenticalInstance()
+        {
+            var dataset = new BasicTextDataset(_testFilePath);
+            var options = DivikOptions.ForLevels(1);
+            options.MaxK = 2;
+            options.Caching = false;
+            options.PlottingPartitions = false;
+            options.PlottingDecomposition = false;
+            options.PlottingDecompositionRecursively = false;
+            options.PlottingRecursively = false;
+            var result = _segmentation.Divik(dataset, options);
+
+            Assert.True(result.Equals(_result), "Equal objects not indicated.");
+        }
+
+        [Test]
+        public void EqualsAgainstDifferentInstance()
+        {
+            var dataset = new BasicTextDataset(_testFilePath);
+            var options = DivikOptions.ForLevels(1);
+            options.MaxK = 2;
+            options.Caching = false;
+            options.PlottingPartitions = false;
+            options.PlottingDecomposition = false;
+            options.PlottingDecompositionRecursively = false;
+            options.PlottingRecursively = false;
+            options.UsingAmplitudeFiltration = false;
+            var result = _segmentation.Divik(dataset, options);
+            
+            Assert.False(result.Equals(_result), "Unequal objects not indicated.");
+        }
+
+        [Test]
+        public void EqualsAgainstNull()
+        {
+            Assert.False(_result.Equals(null), "Instance equalized with null");
+        }
+
+        [Test]
+        public void EqualityOperatorForNulls()
+        {
+            DivikResult r1 = null;
+            DivikResult r2 = null;
+            Assert.True(r1 == r2, "Nulls not indicated as equal");
+        }
+
+        [Test]
+        public void DifferenceOperatorForNulls()
+        {
+            DivikResult r1 = null;
+            DivikResult r2 = null;
+            Assert.False(r1 != r2, "Nulls indicated as unequal");
+        }
+
+        [Test]
+        public void EqualityOperatorAgainstNull()
+        {
+            DivikResult r1 = null;
+            Assert.False(r1 == _result, "null indicated equal to instance");
+        }
+
+        [Test]
+        public void InequalityOperatorAgainstNull()
+        {
+            DivikResult r1 = null;
+            Assert.True(r1 != _result, "null not indicated unequal to instance");
         }
     }
 }

--- a/src/Spectre.Algorithms/Results/DivikResult.cs
+++ b/src/Spectre.Algorithms/Results/DivikResult.cs
@@ -19,6 +19,7 @@
 
 
 using System;
+using System.Linq;
 using MathWorks.MATLAB.NET.Arrays.native;
 
 namespace Spectre.Algorithms.Results
@@ -227,6 +228,91 @@ namespace Spectre.Algorithms.Results
         public void Save(string path)
         {
             throw new NotImplementedException("Result saving has not been implemented yet.");
+        }
+        #endregion
+
+        #region Equals
+
+        /// <summary>
+        /// Determines whether the specified <see cref="System.Object" />, is equal to this instance.
+        /// </summary>
+        /// <param name="obj">The <see cref="System.Object" /> to compare with this instance.</param>
+        /// <returns>
+        ///   <c>true</c> if the specified <see cref="System.Object" /> is equal to this instance; otherwise, <c>false</c>.
+        /// </returns>
+        public override bool Equals(object obj)
+        {
+            if (!(obj is DivikResult))
+                return false;
+
+            if (ReferenceEquals(this, obj))
+                return true;
+
+            var other = (DivikResult) obj;
+
+            if (other.AmplitudeThreshold != this.AmplitudeThreshold)
+                return false;
+            if (other.VarianceThreshold != this.VarianceThreshold)
+                return false;
+            if (other.QualityIndex != this.QualityIndex)
+                return false;
+            if ((other.AmplitudeFilter != null) != (this.AmplitudeFilter != null))
+                return false;
+            if (other.AmplitudeFilter != null && this.AmplitudeFilter != null && other.AmplitudeFilter.Length != this.AmplitudeFilter.Length)
+                return false;
+            if ((other.VarianceFilter != null) != (this.VarianceFilter != null))
+                return false;
+            if (other.VarianceFilter != null && this.VarianceFilter != null && other.VarianceFilter.Length != this.VarianceFilter.Length)
+                return false;
+            if (other.Centroids.Length != this.Centroids.Length)
+                return false;
+            if (other.Partition.Length != this.Partition.Length)
+                return false;
+            if (other.AmplitudeFilter != null && this.AmplitudeFilter != null && !other.AmplitudeFilter.SequenceEqual(this.AmplitudeFilter))
+                return false;
+            if (other.VarianceFilter != null && this.VarianceFilter != null && !other.VarianceFilter.SequenceEqual(this.VarianceFilter))
+                return false;
+            if (!other.Partition.SequenceEqual(this.Partition))
+                return false;
+            if ((other.Merged != null) != (this.Merged != null))
+                return false;
+            if (other.Merged != null && this.Merged != null && !other.Merged.SequenceEqual(this.Merged))
+                return false;
+            if (!other.Centroids.Cast<double>().SequenceEqual(this.Centroids.Cast<double>()))
+                return false;
+            if ((other.Subregions != null) != (this.Subregions != null))
+                return false;
+            if (other.Subregions != null && this.Subregions != null && !other.Subregions.SequenceEqual(this.Subregions))
+                return false;
+
+            return true;
+        }
+
+
+        /// <summary>
+        /// Implements the operator ==.
+        /// </summary>
+        /// <param name="first">First instance to compare.</param>
+        /// <param name="second">Second instance to compare.</param>
+        /// <returns>
+        /// The result of the operator.
+        /// </returns>
+        public static bool operator ==(DivikResult first, DivikResult second)
+        {
+            return ((object)first == null && (object)second == null) || ((object)first != null && first.Equals(second)) || second.Equals(first);
+        }
+
+        /// <summary>
+        /// Implements the operator !=.
+        /// </summary>
+        /// <param name="first">First instance to compare.</param>
+        /// <param name="second">Second instance to compare.</param>
+        /// <returns>
+        /// The result of the operator.
+        /// </returns>
+        public static bool operator !=(DivikResult first, DivikResult second)
+        {
+            return !(first == second);
         }
         #endregion
     }


### PR DESCRIPTION
Simple DivikResult instances comparison is introduced and
takes into account values of fields. Operators == and !=
are also implemented.

This will allow to use simple comparisons outside this
class to check integrity.

Note: GetHashCode has NOT been overriden.

Resolves #70 