### PR TITLE
API preparation list

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -21,6 +21,7 @@ build_script:
 - cmd: msbuild "C:\projects\spectre\src\Spectre.sln" /m /verbosity:quiet /logger:"C:\Program Files\AppVeyor\BuildAgent\Appveyor.MSBuildLogger.dll"
 - cmd: C:\projects\spectre\scripts\build_ng2_client.bat
 after_build:
+- ps: C:\projects\spectre\scripts\BindPageToIisAndCreateDataDir.ps1 -AppVeyor
 - cmd: C:\projects\spectre\scripts\package_project.bat "DiviK.zip" Spectre.DivikWpfClient
 
 test_script:

--- a/scripts/BindPageToIisAndCreateDataDir.ps1
+++ b/scripts/BindPageToIisAndCreateDataDir.ps1
@@ -1,5 +1,6 @@
 Param(
     [switch]$AppVeyor
+    [switch]$Verbose
 )
 
 if($AppVeyor -eq $True)
@@ -12,13 +13,26 @@ else
     $ProjectRoot = Get-Location | Select-String -Pattern spectre -SimpleMatch
 }
 
-Write-Host "Using $($ProjectRoot) as project root."
+function VerbosePrint($text)
+{
+    if($Verbose)
+    {
+        Write-Host $text
+    }
+}
+
+VerbosePrint -text "Using $($ProjectRoot) as project root."
 
 Try
 {
-    Write-Host "Adding $($ProjectRoot)\src\Spectre as an application."
+    VerbosePrint -text "Adding Spectre application pool."
     Import-Module "WebAdministration"
     New-Item 'IIS:\Sites\Default Web Site\spectre_api' -physicalPath "$($ProjectRoot)\src\Spectre" -type Application
+    New-Item 'IIS:\AppPools\Spectre'
+    Set-ItemProperty 'IIS:\AppPools\Spectre' -Name managedRuntimeVersion -Value 'v4.0'
+    Set-ItemProperty 'IIS:\AppPools\Spectre' -Name managedPipelineMode -Value 'Integrated'
+    VerbosePrint -text "Adding $($ProjectRoot)\src\Spectre as an application."
+    Set-ItemProperty 'IIS:\Sites\Default Web Site\spectre_api' -Name applicationPool Spectre
     #New-Item 'IIS:\Sites\Default Web Site\spectre_api' -physicalPath "$($ProjectRoot)\src\Spectre" -type VirtualDirectory
 
     Write-Host "Added API binding to IIS." -foregroundcolor green

--- a/scripts/BindPageToIisAndCreateDataDir.ps1
+++ b/scripts/BindPageToIisAndCreateDataDir.ps1
@@ -1,0 +1,46 @@
+Param(
+    [switch]$AppVeyor
+)
+
+if($AppVeyor -eq $True)
+{
+    $ProjectRoot = "c:\projects\spectre"
+    Set-Location $ProjectRoot
+}
+else
+{
+    $ProjectRoot = Get-Location | Select-String -Pattern spectre -SimpleMatch
+}
+
+Write-Host "Using $($ProjectRoot) as project root."
+
+Try
+{
+    Write-Host "Adding $($ProjectRoot)\src\Spectre as an application."
+    Import-Module "WebAdministration"
+    New-Item 'IIS:\Sites\Default Web Site\spectre_api' -physicalPath "$($ProjectRoot)\src\Spectre" -type Application
+    #New-Item 'IIS:\Sites\Default Web Site\spectre_api' -physicalPath "$($ProjectRoot)\src\Spectre" -type VirtualDirectory
+
+    Write-Host "Added API binding to IIS." -foregroundcolor green
+}
+Catch
+{
+    Write-Host $_.Exception.Message -foregroundcolor red -backgroundcolor black
+    Write-Host "Failed to bind page to IIS." -foregroundcolor red
+}
+
+Try
+{
+    New-Item c:\spectre_data -type Directory
+    $Acl = Get-Acl c:\spectre_data
+    $Ar = New-Object System.Security.AccessControl.FileSystemAccessRule("IIS_IUSRS", "FullControl", "Allow")
+    $Acl.SetAccessRule($Ar)
+    Set-Acl c:\spectre_data $Acl
+    Copy-Item "$($ProjectRoot)\test_files\*" c:\spectre_data
+
+    Write-Host "Test data copied to default data directory." -foregroundcolor green
+}
+Catch
+{
+    Write-Host "Failed to copy data default directory." -foregroundcolor red
+}

--- a/scripts/BindPageToIisAndCreateDataDir.ps1
+++ b/scripts/BindPageToIisAndCreateDataDir.ps1
@@ -1,7 +1,9 @@
 Param(
-    [switch]$AppVeyor
+    [switch]$AppVeyor,
     [switch]$Verbose
 )
+
+if (!([Security.Principal.WindowsPrincipal][Security.Principal.WindowsIdentity]::GetCurrent()).IsInRole([Security.Principal.WindowsBuiltInRole] "Administrator")) { Start-Process powershell.exe "-NoProfile -ExecutionPolicy Bypass -File `"$PSCommandPath`"" -Verb RunAs; exit }
 
 if($AppVeyor -eq $True)
 {
@@ -10,12 +12,14 @@ if($AppVeyor -eq $True)
 }
 else
 {
-    $ProjectRoot = Get-Location | Select-String -Pattern spectre -SimpleMatch
+    $ScriptPath = Split-Path -Parent $MyInvocation.MyCommand.Definition
+    $ProjectRoot = Split-Path -Parent $ScriptPath
+    #$ProjectRoot = Get-Location | Select-String -Pattern spectre -SimpleMatch
 }
 
 function VerbosePrint($text)
 {
-    if($Verbose)
+    if($Verbose -eq $True)
     {
         Write-Host $text
     }
@@ -27,8 +31,8 @@ Try
 {
     VerbosePrint -text "Adding Spectre application pool."
     Import-Module "WebAdministration"
-    New-Item 'IIS:\Sites\Default Web Site\spectre_api' -physicalPath "$($ProjectRoot)\src\Spectre" -type Application
-    New-Item 'IIS:\AppPools\Spectre'
+    New-Item 'IIS:\Sites\Default Web Site\spectre_api' -physicalPath "$($ProjectRoot)\src\Spectre" -type Application | Out-Null
+    New-Item 'IIS:\AppPools\Spectre' | Out-Null
     Set-ItemProperty 'IIS:\AppPools\Spectre' -Name managedRuntimeVersion -Value 'v4.0'
     Set-ItemProperty 'IIS:\AppPools\Spectre' -Name managedPipelineMode -Value 'Integrated'
     VerbosePrint -text "Adding $($ProjectRoot)\src\Spectre as an application."
@@ -45,16 +49,26 @@ Catch
 
 Try
 {
-    New-Item c:\spectre_data -type Directory
+    New-Item c:\spectre_data -type Directory | Out-Null
     $Acl = Get-Acl c:\spectre_data
     $Ar = New-Object System.Security.AccessControl.FileSystemAccessRule("IIS_IUSRS", "FullControl", "Allow")
     $Acl.SetAccessRule($Ar)
     Set-Acl c:\spectre_data $Acl
-    Copy-Item "$($ProjectRoot)\test_files\*" c:\spectre_data
+    Copy-Item "$($ProjectRoot)\test_files\*" c:\spectre_data | Out-Null
 
     Write-Host "Test data copied to default data directory." -foregroundcolor green
 }
 Catch
 {
     Write-Host "Failed to copy data default directory." -foregroundcolor red
+}
+
+Try
+{
+    Invoke-WebRequest -Uri http://localhost/spectre_api/api/preparations/1?spectrumId=1 | Out-Null
+    Write-Host "API available, test data accessible." -foregroundcolor green
+}
+Catch
+{
+    Write-Host "Api is not available." -foregroundcolor red
 }

--- a/src/Spectre.Tests/Controllers/PreparationsControllerTest.cs
+++ b/src/Spectre.Tests/Controllers/PreparationsControllerTest.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using Spectre.Controllers;
+using Spectre.Models.Msi;
+
+namespace Spectre.Tests.Controllers
+{
+    [TestFixture]
+    public class PreparationsControllerTest
+    {
+        private PreparationsController _controller;
+
+        [SetUp]
+        public void SetUp()
+        {
+            _controller = new PreparationsController();
+        }
+
+        [Test]
+        public void TestGetListOfPreparations()
+        {
+            var list = _controller.Get();
+
+            Assert.NotNull(list);
+            Assert.IsNotEmpty(list);
+            Assert.AreEqual(1, list.Count());
+            Assert.AreEqual("Head & neck cancer, patient 1, tumor region only", list.First().Name);
+        }
+
+        [Test]
+        public void TestGetFirstPreparation()
+        {
+            var first = _controller.Get(1);
+
+            Assert.NotNull(first);
+            Assert.IsInstanceOf<Preparation>(first);
+            Assert.AreEqual(1, first.Id);
+            Assert.AreEqual("Head & neck cancer, patient 1, tumor region only", first.Name);
+        }
+
+        [Test]
+        public void TestGetFirstPreparationSampleSpectrum()
+        {
+            var spectrum = _controller.Get(1, 1);
+
+            Assert.NotNull(spectrum);
+            Assert.IsInstanceOf<Spectrum>(spectrum);
+            Assert.IsNotEmpty(spectrum.Intensities);
+            Assert.IsNotEmpty(spectrum.Mz);
+            Assert.AreEqual(spectrum.Mz.Count(), spectrum.Intensities.Count(), "Intensities and Mz counts do not match.");
+        }
+    }
+}

--- a/src/Spectre.Tests/Controllers/PreparationsControllerTest.cs
+++ b/src/Spectre.Tests/Controllers/PreparationsControllerTest.cs
@@ -1,8 +1,23 @@
-﻿using System;
-using System.Collections.Generic;
+﻿/*
+ * PreparationsControllerTest.cs
+ * Test for proper responses after requests.
+ * 
+   Copyright 2017 Grzegorz Mrukwa
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using NUnit.Framework;
 using Spectre.Controllers;
 using Spectre.Models.Msi;

--- a/src/Spectre.Tests/Spectre.Tests.csproj
+++ b/src/Spectre.Tests/Spectre.Tests.csproj
@@ -107,6 +107,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Controllers\PreparationsControllerTest.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Controllers\HomeControllerTest.cs" />
     <Compile Include="Controllers\ValuesControllerTest.cs" />

--- a/src/Spectre/Controllers/PreparationsController.cs
+++ b/src/Spectre/Controllers/PreparationsController.cs
@@ -1,8 +1,23 @@
-﻿using System;
+﻿/*
+ * PreparationsController.cs
+ * Class serving GET requests for preparations.
+ * 
+   Copyright 2017 Grzegorz Mrukwa
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
 using System.Collections.Generic;
-using System.Linq;
-using System.Net;
-using System.Net.Http;
 using System.Web.Http;
 using Spectre.Data.Datasets;
 using Spectre.Models.Msi;

--- a/src/Spectre/Controllers/PreparationsController.cs
+++ b/src/Spectre/Controllers/PreparationsController.cs
@@ -51,7 +51,8 @@ namespace Spectre.Controllers
             var dataset = new BasicTextDataset("C:\\spectre_data\\hnc1_tumor.txt");
 
             var mz = dataset.GetRawMzArray();
-            var intensities = dataset.GetRawIntensityRow(spectrumId);
+
+            var intensities = dataset.GetRawIntensityArray(spectrumId);
             var coordinates = dataset.GetSpatialCoordinates(spectrumId);
 
             return new Spectrum() { Id = spectrumId, Intensities = intensities, Mz = mz, X = coordinates.X, Y = coordinates.Y };

--- a/src/Spectre/Controllers/PreparationsController.cs
+++ b/src/Spectre/Controllers/PreparationsController.cs
@@ -1,0 +1,60 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Web.Http;
+using Spectre.Data.Datasets;
+using Spectre.Models.Msi;
+
+namespace Spectre.Controllers
+{
+    //[Authorize] // should be enabled when authorization is ready
+    /// <summary>
+    /// Allows to read preparation data.
+    /// </summary>
+    /// <seealso cref="System.Web.Http.ApiController" />
+    public class PreparationsController : ApiController
+    {
+        /// <summary>
+        /// GET for the list of preparations.
+        /// </summary>
+        /// <returns>List of preparations.</returns>
+        public IEnumerable<Preparation> Get()
+        {
+            return new[] { new Preparation("Head & neck cancer, patient 1, tumor region only", 1) };
+        }
+
+
+        /// <summary>
+        /// GET for single preparation data.
+        /// </summary>
+        /// <param name="id">Preparation ID.</param>
+        /// <returns>Data of preparation.</returns>
+        public Preparation Get(int id)
+        {
+            return id == 1 ? new Preparation("Head & neck cancer, patient 1, tumor region only", 1) : null;
+        }
+
+
+        /// <summary>
+        /// Gets single spectrum of a specified preparation.
+        /// </summary>
+        /// <param name="id">Preparation identifier.</param>
+        /// <param name="spectrumId">Spectrum identifier.</param>
+        /// <returns>Spectrum</returns>
+        public Spectrum Get(int id, int spectrumId)
+        {
+            if (id != 1)
+                return null;
+
+            var dataset = new BasicTextDataset("C:\\spectre_data\\hnc1_tumor.txt");
+
+            var mz = dataset.GetRawMzArray();
+            var intensities = dataset.GetRawIntensityRow(spectrumId);
+            var coordinates = dataset.GetSpatialCoordinates(spectrumId);
+
+            return new Spectrum() { Id = spectrumId, Intensities = intensities, Mz = mz, X = coordinates.X, Y = coordinates.Y };
+        }
+    }
+}

--- a/src/Spectre/Models/Msi/Preparation.cs
+++ b/src/Spectre/Models/Msi/Preparation.cs
@@ -1,4 +1,23 @@
-﻿using System.Runtime.Serialization;
+﻿/*
+ * Preparation.cs
+ * Class representing single sample in MALDI MSI.
+ * 
+   Copyright 2017 Grzegorz Mrukwa
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+using System.Runtime.Serialization;
 
 namespace Spectre.Models.Msi
 {

--- a/src/Spectre/Models/Msi/Preparation.cs
+++ b/src/Spectre/Models/Msi/Preparation.cs
@@ -2,14 +2,34 @@
 
 namespace Spectre.Models.Msi
 {
+    /// <summary>
+    /// Exhibits general preparation data to API.
+    /// </summary>
     [DataContract]
     public class Preparation
     {
+        /// <summary>
+        /// Gets the name.
+        /// </summary>
+        /// <value>
+        /// The name.
+        /// </value>
         [DataMember]
         public string Name { get; private set; }
+        /// <summary>
+        /// Gets the identifier.
+        /// </summary>
+        /// <value>
+        /// The identifier.
+        /// </value>
         [DataMember]
         public int Id { get; private set; }
 
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Preparation"/> class.
+        /// </summary>
+        /// <param name="name">The name.</param>
+        /// <param name="id">The identifier.</param>
         public Preparation(string name, int id)
         {
             Name = name;

--- a/src/Spectre/Models/Msi/Preparation.cs
+++ b/src/Spectre/Models/Msi/Preparation.cs
@@ -1,0 +1,19 @@
+﻿using System.Runtime.Serialization;
+
+namespace Spectre.Models.Msi
+{
+    [DataContract]
+    public class Preparation
+    {
+        [DataMember]
+        public string Name { get; private set; }
+        [DataMember]
+        public int Id { get; private set; }
+
+        public Preparation(string name, int id)
+        {
+            Name = name;
+            Id = id;
+        }
+    }
+}

--- a/src/Spectre/Models/Msi/Spectrum.cs
+++ b/src/Spectre/Models/Msi/Spectrum.cs
@@ -1,4 +1,23 @@
-﻿using System.Collections.Generic;
+﻿/*
+ * Spectrum.cs
+ * Class representing a single spectrum in a MALDI MSI sample.
+ * 
+   Copyright 2017 Grzegorz Mrukwa
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+using System.Collections.Generic;
 using System.Runtime.Serialization;
 
 namespace Spectre.Models.Msi

--- a/src/Spectre/Models/Msi/Spectrum.cs
+++ b/src/Spectre/Models/Msi/Spectrum.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.Serialization;
+using System.Web;
+
+namespace Spectre.Models.Msi
+{
+    [DataContract]
+    public class Spectrum
+    {
+        [DataMember]
+        public int Id { get; set; }
+        [DataMember]
+        public IEnumerable<double> Mz { get; set; }
+        [DataMember]
+        public IEnumerable<double> Intensities { get; set; }
+        [DataMember]
+        public int X { get; set; }
+        [DataMember]
+        public int Y { get; set; }
+    }
+}

--- a/src/Spectre/Models/Msi/Spectrum.cs
+++ b/src/Spectre/Models/Msi/Spectrum.cs
@@ -1,22 +1,52 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
+﻿using System.Collections.Generic;
 using System.Runtime.Serialization;
-using System.Web;
 
 namespace Spectre.Models.Msi
 {
+    /// <summary>
+    /// Provides details about single spectrum in the dataset.
+    /// </summary>
     [DataContract]
     public class Spectrum
     {
+        /// <summary>
+        /// Gets or sets the identifier of the spectrum.
+        /// </summary>
+        /// <value>
+        /// The identifier.
+        /// </value>
         [DataMember]
         public int Id { get; set; }
+        /// <summary>
+        /// Gets or sets the m/z values.
+        /// </summary>
+        /// <value>
+        /// The mz.
+        /// </value>
         [DataMember]
         public IEnumerable<double> Mz { get; set; }
+        /// <summary>
+        /// Gets or sets the intensities for all m/z-s.
+        /// </summary>
+        /// <value>
+        /// The intensities.
+        /// </value>
         [DataMember]
         public IEnumerable<double> Intensities { get; set; }
+        /// <summary>
+        /// Gets or sets the x coordinate.
+        /// </summary>
+        /// <value>
+        /// The x.
+        /// </value>
         [DataMember]
         public int X { get; set; }
+        /// <summary>
+        /// Gets or sets the y coordinate.
+        /// </summary>
+        /// <value>
+        /// The y.
+        /// </value>
         [DataMember]
         public int Y { get; set; }
     }

--- a/src/Spectre/Spectre.csproj
+++ b/src/Spectre/Spectre.csproj
@@ -17,7 +17,7 @@
     <AssemblyName>Spectre</AssemblyName>
     <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <MvcBuildViews>false</MvcBuildViews>
-    <UseIISExpress>true</UseIISExpress>
+    <UseIISExpress>false</UseIISExpress>
     <IISExpressSSLPort>44388</IISExpressSSLPort>
     <IISExpressAnonymousAuthentication />
     <IISExpressWindowsAuthentication />
@@ -218,6 +218,7 @@
     <Compile Include="Areas\HelpPage\XmlDocumentationProvider.cs" />
     <Compile Include="Controllers\AccountController.cs" />
     <Compile Include="Controllers\HomeController.cs" />
+    <Compile Include="Controllers\PreparationsController.cs" />
     <Compile Include="Controllers\ValuesController.cs" />
     <Compile Include="Global.asax.cs">
       <DependentUpon>Global.asax</DependentUpon>
@@ -225,6 +226,8 @@
     <Compile Include="Models\AccountBindingModels.cs" />
     <Compile Include="Models\AccountViewModels.cs" />
     <Compile Include="Models\IdentityModels.cs" />
+    <Compile Include="Models\Msi\Preparation.cs" />
+    <Compile Include="Models\Msi\Spectrum.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Providers\ApplicationOAuthProvider.cs" />
     <Compile Include="Results\ChallengeResult.cs" />
@@ -290,6 +293,7 @@
   </ItemGroup>
   <ItemGroup>
     <Folder Include="App_Data\" />
+    <Folder Include="Views\Preparations\" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="fonts\glyphicons-halflings-regular.woff" />
@@ -298,6 +302,12 @@
     <Content Include="packages.config" />
     <None Include="Project_Readme.html" />
     <Content Include="Scripts\jquery-1.10.2.min.map" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Spectre.Data\Spectre.Data.csproj">
+      <Project>{70c87af7-3189-4f6c-ac85-93309cf7cfdc}</Project>
+      <Name>Spectre.Data</Name>
+    </ProjectReference>
   </ItemGroup>
   <PropertyGroup>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
@@ -335,7 +345,7 @@
           <AutoAssignPort>True</AutoAssignPort>
           <DevelopmentServerPort>56522</DevelopmentServerPort>
           <DevelopmentServerVPath>/</DevelopmentServerVPath>
-          <IISUrl>http://localhost:56522/</IISUrl>
+          <IISUrl>http://localhost/spectre_api</IISUrl>
           <NTLMAuthentication>False</NTLMAuthentication>
           <UseCustomServer>False</UseCustomServer>
           <CustomServerUrl>


### PR DESCRIPTION
This branch adds mocky preparations list. It returns a single hard-coded preparation just for frontend design purposes. Also adds a possibility to get a single spectrum.

Additionally, a script has been made to bind a page to local IIS and copy test data to a known place.

Partially resolves #15.