### PR TITLE
Add heatmap to PreparationsController

### DIFF
--- a/src/Spectre.Tests/Controllers/PreparationsControllerTest.cs
+++ b/src/Spectre.Tests/Controllers/PreparationsControllerTest.cs
@@ -76,16 +76,20 @@ namespace Spectre.Tests.Controllers
             const double validMzValue = 799.796609809649;
             var heatmap = _controller.Get(1, validMzValue);
 
-            Assert.NotNull(heatmap);
-            Assert.IsInstanceOf<Heatmap>(heatmap);
-            Assert.IsNotEmpty(heatmap.Intensities);
-            Assert.IsNotEmpty(heatmap.X);
-            Assert.IsNotEmpty(heatmap.Y);
-            Assert.AreEqual(heatmap.X.Count(), heatmap.Y.Count(), "Number of coordinates of X and Y do not match.");
-            Assert.AreEqual(heatmap.Intensities.Count(), heatmap.Y.Count(), "Number of coordinates is different from number of intensities.");
+            Assert.Multiple(() =>
+            {
+                Assert.NotNull(heatmap);
+                Assert.IsInstanceOf<Heatmap>(heatmap);
+                Assert.IsNotEmpty(heatmap.Intensities);
+                Assert.IsNotEmpty(heatmap.X);
+                Assert.IsNotEmpty(heatmap.Y);
+                Assert.AreEqual(heatmap.X.Count(), heatmap.Y.Count(), "Number of coordinates of X and Y do not match.");
+                Assert.AreEqual(heatmap.Intensities.Count(), heatmap.Y.Count(),
+                    "Number of coordinates is different from number of intensities.");
 
-            Assert.Throws<ArgumentException>(() => { _controller.Get(1, -2.0); }, "Accepted negative mz value");
-            Assert.Throws<ArgumentException>(() => { _controller.Get(1, 0.0); }, "Accepted nonexistent mz value");
+                Assert.Throws<ArgumentException>(() => { _controller.Get(1, -2.0); }, "Accepted negative mz value");
+                Assert.Throws<ArgumentException>(() => { _controller.Get(1, 0.0); }, "Accepted nonexistent mz value");
+            });
         }
     }
 }

--- a/src/Spectre.Tests/Controllers/PreparationsControllerTest.cs
+++ b/src/Spectre.Tests/Controllers/PreparationsControllerTest.cs
@@ -17,6 +17,7 @@
    limitations under the License.
 */
 
+using System;
 using System.Linq;
 using NUnit.Framework;
 using Spectre.Controllers;
@@ -67,6 +68,24 @@ namespace Spectre.Tests.Controllers
             Assert.IsNotEmpty(spectrum.Intensities);
             Assert.IsNotEmpty(spectrum.Mz);
             Assert.AreEqual(spectrum.Mz.Count(), spectrum.Intensities.Count(), "Intensities and Mz counts do not match.");
+        }
+
+        [Test]
+        public void TestGetFirstPreparationSampleHeatmap()
+        {
+            const double validMzValue = 799.796609809649;
+            var heatmap = _controller.Get(1, validMzValue);
+
+            Assert.NotNull(heatmap);
+            Assert.IsInstanceOf<Heatmap>(heatmap);
+            Assert.IsNotEmpty(heatmap.Intensities);
+            Assert.IsNotEmpty(heatmap.X);
+            Assert.IsNotEmpty(heatmap.Y);
+            Assert.AreEqual(heatmap.X.Count(), heatmap.Y.Count(), "Number of coordinates of X and Y do not match.");
+            Assert.AreEqual(heatmap.Intensities.Count(), heatmap.Y.Count(), "Number of coordinates is different from number of intensities.");
+
+            Assert.Throws<ArgumentException>(() => { _controller.Get(1, -2.0); }, "Accepted negative mz value");
+            Assert.Throws<ArgumentException>(() => { _controller.Get(1, 0.0); }, "Accepted nonexistent mz value");
         }
     }
 }

--- a/src/Spectre.Tests/Controllers/PreparationsControllerTest.cs
+++ b/src/Spectre.Tests/Controllers/PreparationsControllerTest.cs
@@ -2,7 +2,7 @@
  * PreparationsControllerTest.cs
  * Test for proper responses after requests.
  * 
-   Copyright 2017 Grzegorz Mrukwa
+   Copyright 2017 Grzegorz Mrukwa, Michał Gallus
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/src/Spectre/Models/Msi/Heatmap.cs
+++ b/src/Spectre/Models/Msi/Heatmap.cs
@@ -1,0 +1,64 @@
+﻿/*
+ * Heatmap.cs
+ * Class representing single heatmap in MALDI MSI sample.
+ * 
+   Copyright 2017 Michał Gallus
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+using System.Collections.Generic;
+using System.Runtime.Serialization;
+
+namespace Spectre.Models.Msi
+{
+    [DataContract]
+    public class Heatmap
+    {
+        /// <summary>
+        /// Gets or sets the mz identifier of the spectrum.
+        /// </summary>
+        /// <value>
+        /// The identifier.
+        /// </value>
+        [DataMember]
+        public double Mz { get; set; }
+
+        /// <summary>
+        /// Gets or sets the intensities for all coordinates.
+        /// </summary>
+        /// <value>
+        /// The intensities.
+        /// </value>
+        [DataMember]
+        public IEnumerable<double> Intensities { get; set; }
+
+        /// <summary>
+        /// Gets or sets the x coordinates.
+        /// </summary>
+        /// <value>
+        /// The x.
+        /// </value>
+        [DataMember]
+        public IEnumerable<int> X { get; set; }
+
+        /// <summary>
+        /// Gets or sets the y coordinates.
+        /// </summary>
+        /// <value>
+        /// The y.
+        /// </value>
+        [DataMember]
+        public IEnumerable<int> Y { get; set; }
+    }
+}

--- a/src/Spectre/Models/Msi/Heatmap.cs
+++ b/src/Spectre/Models/Msi/Heatmap.cs
@@ -22,6 +22,9 @@ using System.Runtime.Serialization;
 
 namespace Spectre.Models.Msi
 {
+    /// <summary>
+    /// Provides details about a single heatmap in the dataset.
+    /// </summary>
     [DataContract]
     public class Heatmap
     {

--- a/src/Spectre/Spectre.csproj
+++ b/src/Spectre/Spectre.csproj
@@ -17,7 +17,7 @@
     <AssemblyName>Spectre</AssemblyName>
     <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <MvcBuildViews>false</MvcBuildViews>
-    <UseIISExpress>true</UseIISExpress>
+    <UseIISExpress>false</UseIISExpress>
     <IISExpressSSLPort>44388</IISExpressSSLPort>
     <IISExpressAnonymousAuthentication />
     <IISExpressWindowsAuthentication />

--- a/src/Spectre/Spectre.csproj
+++ b/src/Spectre/Spectre.csproj
@@ -17,7 +17,7 @@
     <AssemblyName>Spectre</AssemblyName>
     <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
     <MvcBuildViews>false</MvcBuildViews>
-    <UseIISExpress>false</UseIISExpress>
+    <UseIISExpress>true</UseIISExpress>
     <IISExpressSSLPort>44388</IISExpressSSLPort>
     <IISExpressAnonymousAuthentication />
     <IISExpressWindowsAuthentication />
@@ -234,6 +234,7 @@
     <Compile Include="Models\AccountBindingModels.cs" />
     <Compile Include="Models\AccountViewModels.cs" />
     <Compile Include="Models\IdentityModels.cs" />
+    <Compile Include="Models\Msi\Heatmap.cs" />
     <Compile Include="Models\Msi\Preparation.cs" />
     <Compile Include="Models\Msi\Spectrum.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />


### PR DESCRIPTION
Heatmap can now be accessed through the web interface using following address:
```
http://localhost/spectre_api/api/preparations/1?mz=<value>
```
for example
```
http://localhost/spectre_api/api/preparations/1?mz=799.796609809649
```

It outputs the spatial coordinates and intensities corresponding to provided mz value.

Exemplary output:
![image](https://cloud.githubusercontent.com/assets/4967505/26267424/5b4313ca-3cea-11e7-9912-6531d0fad317.png)

