### PR TITLE
Feature/add routing frontend

### DIFF
--- a/src/Spectre.Angular2Client/src/app/app.component.html
+++ b/src/Spectre.Angular2Client/src/app/app.component.html
@@ -1,24 +1,5 @@
-<--
-   app.component.html
-   Visual composition of application root element.
-
-   Copyright 2017 Sebastian Pustelnik, Grzegorz Mrukwa
-
-   Licensed under the Apache License, Version 2.0 (the "License");
-   you may not use this file except in compliance with the License.
-   You may obtain a copy of the License at
-
-       http://www.apache.org/licenses/LICENSE-2.0
-
-   Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an "AS IS" BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-   See the License for the specific language governing permissions and
-   limitations under the License.
--->
-
 <h1>
   {{title}}
 </h1>
 
-<app-preparation-list></app-preparation-list>
+<router-outlet></router-outlet>

--- a/src/Spectre.Angular2Client/src/app/app.component.spec.ts
+++ b/src/Spectre.Angular2Client/src/app/app.component.spec.ts
@@ -27,9 +27,14 @@ import { PreparationListComponent } from './preparation-list/preparation-list.co
 
 import { MockBackend } from '@angular/http/testing';
 
+import { RouterTestingModule } from '@angular/router/testing';
+
 describe('AppComponent', () => {
   beforeEach(async(() => {
     TestBed.configureTestingModule({
+      imports: [
+          RouterTestingModule
+      ],
       providers: [
           MockBackend,
           BaseRequestOptions,

--- a/src/Spectre.Angular2Client/src/app/app.module.ts
+++ b/src/Spectre.Angular2Client/src/app/app.module.ts
@@ -22,19 +22,26 @@ import { NgModule } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { HttpModule } from '@angular/http';
 
+import { routing } from './app.routing';
+
 import { AppComponent } from './app.component';
 import { PreparationListComponent } from './preparation-list/preparation-list.component';
 import { PreparationService } from './preparation-list/preparation.service';
+import { PreparationsModule } from './preparation/preparations.module';
+import { PageNotFoundComponent } from './page-not-found/page-not-found.component';
 
 @NgModule({
   declarations: [
     AppComponent,
-    PreparationListComponent
+    PreparationListComponent,
+    PageNotFoundComponent
   ],
   imports: [
     BrowserModule,
     FormsModule,
-    HttpModule
+    HttpModule,
+    PreparationsModule,
+    routing
   ],
   bootstrap: [AppComponent]
 })

--- a/src/Spectre.Angular2Client/src/app/app.routing.ts
+++ b/src/Spectre.Angular2Client/src/app/app.routing.ts
@@ -1,0 +1,14 @@
+import { ModuleWithProviders } from '@angular/core';
+import { Routes, RouterModule } from '@angular/router';
+
+import { PageNotFoundComponent } from './page-not-found/page-not-found.component';
+import { PreparationListComponent } from './preparation-list/preparation-list.component';
+import { PreparationComponent } from './preparation/preparation.component';
+
+const appRoutes: Routes = [
+  { path: '', component: PreparationListComponent, pathMatch: 'full'}, // redirect to home page on load
+  { path: 'preparations', component: PreparationListComponent, pathMatch: 'full'},
+  { path: '**', component: PageNotFoundComponent }
+];
+
+export const routing: ModuleWithProviders = RouterModule.forRoot(appRoutes);

--- a/src/Spectre.Angular2Client/src/app/app.routing.ts
+++ b/src/Spectre.Angular2Client/src/app/app.routing.ts
@@ -1,3 +1,22 @@
+/*
+ * app.routing.ts
+ * Root for routing throught the app.
+ *
+   Copyright 2017 Grzegorz Mrukwa
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
 import { ModuleWithProviders } from '@angular/core';
 import { Routes, RouterModule } from '@angular/router';
 

--- a/src/Spectre.Angular2Client/src/app/page-not-found/page-not-found.component.css
+++ b/src/Spectre.Angular2Client/src/app/page-not-found/page-not-found.component.css
@@ -1,0 +1,4 @@
+div {
+    vertical-align: middle;
+    text-align: center;
+}

--- a/src/Spectre.Angular2Client/src/app/page-not-found/page-not-found.component.html
+++ b/src/Spectre.Angular2Client/src/app/page-not-found/page-not-found.component.html
@@ -1,0 +1,3 @@
+<p>
+  page-not-found works!
+</p>

--- a/src/Spectre.Angular2Client/src/app/page-not-found/page-not-found.component.html
+++ b/src/Spectre.Angular2Client/src/app/page-not-found/page-not-found.component.html
@@ -1,3 +1,7 @@
-<p>
-  page-not-found works!
-</p>
+<div>
+    <h1>
+      Page has not been found.
+    </h1>
+
+    <a href="./">Home</a>
+</div>

--- a/src/Spectre.Angular2Client/src/app/page-not-found/page-not-found.component.spec.ts
+++ b/src/Spectre.Angular2Client/src/app/page-not-found/page-not-found.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { PageNotFoundComponent } from './page-not-found.component';
+
+describe('PageNotFoundComponent', () => {
+  let component: PageNotFoundComponent;
+  let fixture: ComponentFixture<PageNotFoundComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ PageNotFoundComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(PageNotFoundComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/Spectre.Angular2Client/src/app/page-not-found/page-not-found.component.spec.ts
+++ b/src/Spectre.Angular2Client/src/app/page-not-found/page-not-found.component.spec.ts
@@ -1,3 +1,22 @@
+/*
+ * page-not-found.component.spec.ts
+ * Unit tests for error 404 page.
+ *
+   Copyright 2017 Grzegorz Mrukwa
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { PageNotFoundComponent } from './page-not-found.component';
@@ -21,5 +40,10 @@ describe('PageNotFoundComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should provide way to go home', () => {
+    const compiled = fixture.debugElement.nativeElement;
+    expect(compiled.querySelector('a').textContent).toContain('Home');
   });
 });

--- a/src/Spectre.Angular2Client/src/app/page-not-found/page-not-found.component.ts
+++ b/src/Spectre.Angular2Client/src/app/page-not-found/page-not-found.component.ts
@@ -1,0 +1,15 @@
+import { Component, OnInit } from '@angular/core';
+
+@Component({
+  selector: 'app-page-not-found',
+  templateUrl: './page-not-found.component.html',
+  styleUrls: ['./page-not-found.component.css']
+})
+export class PageNotFoundComponent implements OnInit {
+
+  constructor() { }
+
+  ngOnInit() {
+  }
+
+}

--- a/src/Spectre.Angular2Client/src/app/page-not-found/page-not-found.component.ts
+++ b/src/Spectre.Angular2Client/src/app/page-not-found/page-not-found.component.ts
@@ -1,3 +1,22 @@
+/*
+ * page-not-found.component.ts
+ * Component for error 404.
+ *
+   Copyright 2017 Grzegorz Mrukwa
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
 import { Component, OnInit } from '@angular/core';
 
 @Component({

--- a/src/Spectre.Angular2Client/src/app/preparation-list/preparation-list.component.html
+++ b/src/Spectre.Angular2Client/src/app/preparation-list/preparation-list.component.html
@@ -1,28 +1,12 @@
-<--
-   preparation-list.component.html
-   Displayable elements of preparations list.
-
-   Copyright 2017 Sebastian Pustelnik, Grzegorz Mrukwa
-
-   Licensed under the Apache License, Version 2.0 (the "License");
-   you may not use this file except in compliance with the License.
-   You may obtain a copy of the License at
-
-       http://www.apache.org/licenses/LICENSE-2.0
-
-   Unless required by applicable law or agreed to in writing, software
-   distributed under the License is distributed on an "AS IS" BASIS,
-   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-   See the License for the specific language governing permissions and
-   limitations under the License.
--->
-
 <div>
     <h2>There are {{preparations.length}} available preparations:</h2>
 
     <div class="preparation-list">
         <div class="preparation" *ngFor="let preparation of preparations">
-            {{preparation.name}}
+            <a routerLink="preparation/{{preparation.id}}"
+                routerLinkActive="active">
+                {{preparation.name}}
+            </a>
         </div>
     </div>
 </div>

--- a/src/Spectre.Angular2Client/src/app/preparation-list/preparation-list.component.spec.ts
+++ b/src/Spectre.Angular2Client/src/app/preparation-list/preparation-list.component.spec.ts
@@ -25,12 +25,17 @@ import { Http, BaseRequestOptions } from '@angular/http';
 
 import { MockBackend } from '@angular/http/testing';
 
+import { RouterTestingModule } from '@angular/router/testing';
+
 describe('PreparationListComponent', () => {
   let component: PreparationListComponent;
   let fixture: ComponentFixture<PreparationListComponent>;
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
+      imports: [
+          RouterTestingModule
+      ],
       providers: [
           MockBackend,
           BaseRequestOptions,

--- a/src/Spectre.Angular2Client/src/app/preparation/preparation-routing.module.ts
+++ b/src/Spectre.Angular2Client/src/app/preparation/preparation-routing.module.ts
@@ -1,3 +1,22 @@
+/*
+ * preparation-routing.module.ts
+ * Module providing routing to single preparations.
+ *
+   Copyright 2017 Grzegorz Mrukwa
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
 import { NgModule } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
 

--- a/src/Spectre.Angular2Client/src/app/preparation/preparation-routing.module.ts
+++ b/src/Spectre.Angular2Client/src/app/preparation/preparation-routing.module.ts
@@ -1,0 +1,19 @@
+import { NgModule } from '@angular/core';
+import { RouterModule, Routes } from '@angular/router';
+
+import { PreparationComponent } from './preparation.component';
+
+const preparationRoutes = [
+    { path: 'preparation/:id', component: PreparationComponent }
+];
+
+@NgModule({
+    imports: [
+        RouterModule.forChild(preparationRoutes)
+    ],
+    exports: [
+        RouterModule
+    ]
+})
+
+export class PreparationRoutingModule { }

--- a/src/Spectre.Angular2Client/src/app/preparation/preparation.component.html
+++ b/src/Spectre.Angular2Client/src/app/preparation/preparation.component.html
@@ -1,0 +1,3 @@
+<p>
+  preparation {{id}} works!
+</p>

--- a/src/Spectre.Angular2Client/src/app/preparation/preparation.component.spec.ts
+++ b/src/Spectre.Angular2Client/src/app/preparation/preparation.component.spec.ts
@@ -1,0 +1,40 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { PreparationComponent } from './preparation.component';
+
+import { ActivatedRoute } from '@angular/router';
+import { MockActivatedRoute } from '../../mocks/mock-activated-router';
+import { RouterTestingModule } from '@angular/router/testing';
+import { Observable } from 'rxjs/Observable';
+
+describe('PreparationComponent', () => {
+  let component: PreparationComponent;
+  let fixture: ComponentFixture<PreparationComponent>;
+  let mockActivatedRoute: MockActivatedRoute;
+
+  beforeEach(async(() => {
+    mockActivatedRoute = new MockActivatedRoute(Observable.of({id: '100'}));
+    TestBed.configureTestingModule({
+      declarations: [ PreparationComponent ],
+      imports: [RouterTestingModule],
+      providers: [
+          { provide: ActivatedRoute, useValue: mockActivatedRoute }
+      ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(PreparationComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should contain proper preparation number', () => {
+      expect(component.id).toEqual(100);
+  });
+});

--- a/src/Spectre.Angular2Client/src/app/preparation/preparation.component.spec.ts
+++ b/src/Spectre.Angular2Client/src/app/preparation/preparation.component.spec.ts
@@ -1,3 +1,22 @@
+/*
+ * preparation.component.spec.ts
+ * Unit tests for single preparation component.
+ *
+   Copyright 2017 Grzegorz Mrukwa
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { PreparationComponent } from './preparation.component';

--- a/src/Spectre.Angular2Client/src/app/preparation/preparation.component.ts
+++ b/src/Spectre.Angular2Client/src/app/preparation/preparation.component.ts
@@ -1,0 +1,25 @@
+import { Component, OnInit } from '@angular/core';
+import { ActivatedRoute, Params } from '@angular/router';
+
+import { PreparationRoutingModule } from './preparation-routing.module';
+
+@Component({
+  selector: 'app-preparation',
+  templateUrl: './preparation.component.html',
+  styleUrls: ['./preparation.component.css']
+})
+export class PreparationComponent implements OnInit {
+
+  id: number = null;
+
+  constructor(
+      private route: ActivatedRoute,
+  ) { }
+
+  ngOnInit() {
+      this.route.params.subscribe(params => {
+          this.id = Number.parseInt(params['id']);
+      });
+  }
+
+}

--- a/src/Spectre.Angular2Client/src/app/preparation/preparation.component.ts
+++ b/src/Spectre.Angular2Client/src/app/preparation/preparation.component.ts
@@ -1,3 +1,22 @@
+/*
+ * preparation.component.ts
+ * Component of single preparation.
+ *
+   Copyright 2017 Grzegorz Mrukwa
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
 import { Component, OnInit } from '@angular/core';
 import { ActivatedRoute, Params } from '@angular/router';
 

--- a/src/Spectre.Angular2Client/src/app/preparation/preparations.module.ts
+++ b/src/Spectre.Angular2Client/src/app/preparation/preparations.module.ts
@@ -1,3 +1,22 @@
+/*
+ * preparations.module.ts
+ * Module with preparations-related stuff (routing, imports declarations, etc.).
+ *
+   Copyright 2017 Grzegorz Mrukwa
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';

--- a/src/Spectre.Angular2Client/src/app/preparation/preparations.module.ts
+++ b/src/Spectre.Angular2Client/src/app/preparation/preparations.module.ts
@@ -1,0 +1,20 @@
+import { NgModule } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormsModule } from '@angular/forms';
+
+import { PreparationComponent } from './preparation.component';
+
+import { PreparationRoutingModule } from './preparation-routing.module';
+
+@NgModule({
+  imports: [
+    CommonModule,
+    FormsModule,
+    PreparationRoutingModule
+  ],
+  declarations: [
+    PreparationComponent
+  ],
+  providers: [  ]
+})
+export class PreparationsModule {}

--- a/src/Spectre.Angular2Client/src/mocks/mock-activated-router.ts
+++ b/src/Spectre.Angular2Client/src/mocks/mock-activated-router.ts
@@ -1,0 +1,24 @@
+import { ActivatedRoute, ActivatedRouteSnapshot, Params } from '@angular/router';
+import { Observable } from 'rxjs/Observable';
+
+class MockActivatedRouteSnapshot extends ActivatedRouteSnapshot {
+    params: Observable<Params>;
+    constructor(parameters: Observable<Params>) {
+        super();
+        this.params = parameters;
+    }
+
+    toString(): string {
+        return '';
+    }
+}
+
+export class MockActivatedRoute extends ActivatedRoute {
+  params: Observable<Params>;
+
+  constructor(parameters: Observable<Params>) {
+    super();
+    this.params = parameters;
+    this.snapshot = new MockActivatedRouteSnapshot(this.params);
+  }
+}

--- a/src/Spectre.Angular2Client/src/mocks/mock-activated-router.ts
+++ b/src/Spectre.Angular2Client/src/mocks/mock-activated-router.ts
@@ -1,3 +1,22 @@
+/*
+ * mock-activated-router.ts
+ * Mock for ActivatedRoute to check behaviour on different URL params.
+ *
+   Copyright 2017 Grzegorz Mrukwa
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
 import { ActivatedRoute, ActivatedRouteSnapshot, Params } from '@angular/router';
 import { Observable } from 'rxjs/Observable';
 


### PR DESCRIPTION
This branch adds single preparation component (which now just shows the ID of preparation navigated to), along with routing and sample *404* page.