### PR TITLE
Increase warning level

### DIFF
--- a/src/Spectre.Algorithms.Tests/Methods/GmmModellingTests.cs
+++ b/src/Spectre.Algorithms.Tests/Methods/GmmModellingTests.cs
@@ -46,7 +46,7 @@ namespace Spectre.Algorithms.Tests.Methods
 		[Test]
 		public void EstimateGmm()
 		{
-			IDataset dataset = new BasicTextDataset(mz, data);
+			IDataset dataset = new BasicTextDataset(mz, data, null);
 
 			var result = _gmm.EstimateGmm(dataset);
 
@@ -69,7 +69,7 @@ namespace Spectre.Algorithms.Tests.Methods
 		[Test]
 		public void ApplyGmm()
 		{
-			IDataset dataset = new BasicTextDataset(mz, data);
+			IDataset dataset = new BasicTextDataset(mz, data, null);
 
             var model = _gmm.EstimateGmm(dataset);
 
@@ -84,7 +84,7 @@ namespace Spectre.Algorithms.Tests.Methods
 	    [Test]
 	    public void ReduceByHeight()
 	    {
-            IDataset dataset = new BasicTextDataset(mz, data);
+            IDataset dataset = new BasicTextDataset(mz, data, null);
 
             var model = _gmm.EstimateGmm(dataset);
 
@@ -111,7 +111,7 @@ namespace Spectre.Algorithms.Tests.Methods
 	    [Test]
 	    public void ReduceByArea()
 	    {
-            IDataset dataset = new BasicTextDataset(mz, data);
+            IDataset dataset = new BasicTextDataset(mz, data, null);
 
             var model = _gmm.EstimateGmm(dataset);
 
@@ -138,7 +138,7 @@ namespace Spectre.Algorithms.Tests.Methods
 	    [Test]
 	    public void MergeComonents()
 	    {
-            IDataset dataset = new BasicTextDataset(mz, data);
+            IDataset dataset = new BasicTextDataset(mz, data, null);
 
             var model = _gmm.EstimateGmm(dataset);
 

--- a/src/Spectre.Algorithms.Tests/Methods/PreprocessingTests.cs
+++ b/src/Spectre.Algorithms.Tests/Methods/PreprocessingTests.cs
@@ -45,7 +45,7 @@ namespace Spectre.Algorithms.Tests.Methods
 			double[] mz = { 1.1, 1.2, 0.97, 1.07, 1.02, 5, 1.2, 1.5, 1.6, 1.2 };
 			double[,] data = { { 1.1, 1.2, 0.97, 1.07, 1.02, 5, 1.2, 1.5, 1.6, 1.2 }, { 1.1, 1.2, 0.97, 1.07, 1.02, 5, 1.2, 1.5, 1.6, 1.2 },
 				{ 1.1, 1.2, 0.97, 1.07, 1.02, 5, 1.2, 1.5, 1.6, 1.2 }, { 1.1, 1.2, 0.97, 1.07, 1.02, 5, 1.2, 1.5, 1.6, 1.2 } };
-            IDataset dataset = new BasicTextDataset(mz, data);
+            IDataset dataset = new BasicTextDataset(mz, data, null);
 
             IDataset result = _preprocessing.RemoveBaseline(dataset);
 
@@ -58,7 +58,7 @@ namespace Spectre.Algorithms.Tests.Methods
 		{
 			double[] mz = { 1, 1, 1 };
 			double[,] data = { { 1, 1, 1 }, { 1, 1, 1 }, { 1, 1, 1 } };
-            IDataset dataset = new BasicTextDataset(mz, data);
+            IDataset dataset = new BasicTextDataset(mz, data, null);
 
             IDataset result = _preprocessing.AlignPeaksFft(dataset);
 
@@ -72,7 +72,7 @@ namespace Spectre.Algorithms.Tests.Methods
             double[] mz = { 1, 2, 3, 4, 5, 6, 7, 8, 9, 10 };
             double[,] data = { { 1.1, 1.2, 0.97, 1.07, 1.02, 5, 1.2, 1.5, 1.6, 1.2 }, { 1.1, 1.2, 0.97, 1.07, 1.02, 5, 1.2, 1.5, 1.6, 1.2 },
 				{ 1.1, 1.2, 0.97, 1.07, 1.02, 5, 1.2, 1.5, 1.6, 1.2 }, { 1.1, 1.2, 0.97, 1.07, 1.02, 5, 1.2, 1.5, 1.6, 1.2 } };
-            IDataset dataset = new BasicTextDataset(mz, data);
+            IDataset dataset = new BasicTextDataset(mz, data, null);
 
             IDataset result = _preprocessing.NormalizeByTic(dataset);
 

--- a/src/Spectre.Algorithms.Tests/Methods/Utils/PartitionTests.cs
+++ b/src/Spectre.Algorithms.Tests/Methods/Utils/PartitionTests.cs
@@ -70,13 +70,15 @@ namespace Spectre.Algorithms.Tests.Methods.Utils
         #endregion
 
         #region Compare
+        private const double DefaultTolerance = 0.0;
+
         [Test]
         public void IntPartitionComparisonThrowExceptionOnNull()
         {
             var notNull = new[] {1};
-            Assert.Throws<ArgumentNullException>(() => Partition.Compare<int, int>(null, null));
-            Assert.Throws<ArgumentNullException>(() => Partition.Compare<int, int>(notNull, null));
-            Assert.Throws<ArgumentNullException>(() => Partition.Compare<int, int>(null, notNull));
+            Assert.Throws<ArgumentNullException>(() => Partition.Compare<int, int>(null, null, DefaultTolerance));
+            Assert.Throws<ArgumentNullException>(() => Partition.Compare<int, int>(notNull, null, DefaultTolerance));
+            Assert.Throws<ArgumentNullException>(() => Partition.Compare<int, int>(null, notNull, DefaultTolerance));
         }
 
         [Test]
@@ -84,7 +86,7 @@ namespace Spectre.Algorithms.Tests.Methods.Utils
         {
             var partition = new[] { 1, 2 };
             var another = new[] { 1, 1, 1 };
-            Assert.Throws<ArgumentException>(() => Partition.Compare(partition, another),
+            Assert.Throws<ArgumentException>(() => Partition.Compare(partition, another, DefaultTolerance),
                 "Does not throw on partition length mismatch.");
         }
 
@@ -92,7 +94,7 @@ namespace Spectre.Algorithms.Tests.Methods.Utils
         public void IntEqualPartitionComparisonWithoutTolerance()
         {
             var partition = new[] {1, 2};
-            var result = Partition.Compare(partition, partition);
+            var result = Partition.Compare(partition, partition, 0);
             Assert.True(result, "The same instance found unequal.");
         }
 
@@ -101,7 +103,7 @@ namespace Spectre.Algorithms.Tests.Methods.Utils
         {
             var partition = new[] { 1, 2 };
             var another = new[] {1, 1};
-            var result = Partition.Compare(partition, another);
+            var result = Partition.Compare(partition, another, 0);
             Assert.False(result, "Another partition found equal.");
         }
 
@@ -110,7 +112,7 @@ namespace Spectre.Algorithms.Tests.Methods.Utils
         {
             var partition = new[] {1, 2, 2};
             var equalOne = new[] {2, 1, 1};
-            var result = Partition.Compare(partition, equalOne);
+            var result = Partition.Compare(partition, equalOne, 0);
             Assert.True(result, "Equality is label-sensitive.");
         }
 
@@ -119,7 +121,7 @@ namespace Spectre.Algorithms.Tests.Methods.Utils
         {
             var partition = new[] { 1, 2, 3, 1 };
             var equalOne = new[] { "Ala", "nie ma", "kota", "Ala" };
-            var result = Partition.Compare(partition, equalOne);
+            var result = Partition.Compare(partition, equalOne, 0);
             Assert.True(result, "Equality is type-sensitive.");
         }
 

--- a/src/Spectre.Algorithms.Tests/Results/DivikResultTests.cs
+++ b/src/Spectre.Algorithms.Tests/Results/DivikResultTests.cs
@@ -62,7 +62,7 @@ namespace Spectre.Algorithms.Tests.Results
         public void Save()
         {
             string path = TestDirectory + "\\test-path.json";
-            _result.Save(path);
+            _result.Save(path, true);
 
             Assert.True(File.Exists(path), "File doesn't exist");
             Assert.AreNotEqual(0, new FileInfo(path).Length, "File is empty");

--- a/src/Spectre.Algorithms.Tests/Spectre.Algorithms.Tests.csproj
+++ b/src/Spectre.Algorithms.Tests/Spectre.Algorithms.Tests.csproj
@@ -26,6 +26,7 @@
     <PlatformTarget>x64</PlatformTarget>
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
     <OutputPath>bin\x64\Release\</OutputPath>

--- a/src/Spectre.Algorithms/Methods/GmmModelling.cs
+++ b/src/Spectre.Algorithms/Methods/GmmModelling.cs
@@ -102,10 +102,10 @@ namespace Spectre.Algorithms.Methods
             ValidateDispose();
             throw new NotImplementedException(nameof(ReduceModelByComponentArea) + " is not implemented.");
 
-            var matlabModel = model.MatlabStruct;
-            // @gmrukwa: this has an issue with opts.thr -> it must be defined, but no one knows how
-            var reduced = _gmm.reduce_gmm_by_component_area(matlabModel, model.OriginalMz, model.OriginalMeanSpectrum);
-            return new GmmModel(reduced, model) { IsNoiseReduced = true };
+            //var matlabModel = model.MatlabStruct;
+            //// @gmrukwa: this has an issue with opts.thr -> it must be defined, but no one knows how
+            //var reduced = _gmm.reduce_gmm_by_component_area(matlabModel, model.OriginalMz, model.OriginalMeanSpectrum);
+            //return new GmmModel(reduced, model) { IsNoiseReduced = true };
         }
 
         /// <summary>
@@ -120,10 +120,10 @@ namespace Spectre.Algorithms.Methods
             ValidateDispose();
 	        throw new NotImplementedException(nameof(ReduceModelByComponentHeight) + " is not implemented.");
 
-            var matlabModel = model.MatlabStruct;
-            // @gmrukwa: this has an issue with opts.thr -> it must be defined, but no one knows how
-            var reduced = _gmm.reduce_gmm_by_component_height(matlabModel, model.OriginalMz, model.OriginalMeanSpectrum);
-            return new GmmModel(reduced, model) { IsNoiseReduced = true };
+            //var matlabModel = model.MatlabStruct;
+            //// @gmrukwa: this has an issue with opts.thr -> it must be defined, but no one knows how
+            //var reduced = _gmm.reduce_gmm_by_component_height(matlabModel, model.OriginalMz, model.OriginalMeanSpectrum);
+            //return new GmmModel(reduced, model) { IsNoiseReduced = true };
         }
 
         /// <summary>

--- a/src/Spectre.Algorithms/Methods/Utils/Partition.cs
+++ b/src/Spectre.Algorithms/Methods/Utils/Partition.cs
@@ -38,7 +38,7 @@ namespace Spectre.Algorithms.Methods.Utils
         /// <returns><value>true</value>, if partitions match; <value>false</value> otherwise.</returns>
         /// <exception cref="System.ArgumentException">Lengths of partitions differ.</exception>
         /// <exception cref="ArgumentNullException">Any of partitions is null.</exception>
-        public static bool Compare<T1,T2>(IEnumerable<T1> partition1, IEnumerable<T2> partition2, double tolerance = 0)
+        public static bool Compare<T1,T2>(IEnumerable<T1> partition1, IEnumerable<T2> partition2, double tolerance)
         {
             if(partition1 == null)
                 throw new ArgumentNullException(nameof(partition1));

--- a/src/Spectre.Algorithms/Results/DivikResult.cs
+++ b/src/Spectre.Algorithms/Results/DivikResult.cs
@@ -240,10 +240,10 @@ namespace Spectre.Algorithms.Results
         /// Saves result under the specified path in JSON format.
         /// </summary>
         /// <param name="path">The destination path.</param>
-        /// <param name="identation">Sets idented formattings. Defaults to true.</param>
-        public void Save(string path, bool identation = true)
+        /// <param name="indentation">Sets indented formattings.</param>
+        public void Save(string path, bool indentation)
         {
-            Formatting format = identation ? Formatting.Indented : Formatting.None;
+            Formatting format = indentation ? Formatting.Indented : Formatting.None;
             string data = JsonConvert.SerializeObject(this, format);
             File.WriteAllText(path, data);
         }
@@ -333,6 +333,23 @@ namespace Spectre.Algorithms.Results
         {
             return !(first == second);
         }
+
+        public override int GetHashCode()
+        {
+            var hash = 17;
+            hash = 23 * hash + AmplitudeThreshold.GetHashCode();
+            hash = 23 * hash + VarianceThreshold.GetHashCode();
+            hash = 23 * hash + QualityIndex.GetHashCode();
+            hash = 23 * hash + AmplitudeFilter.GetHashCode();
+            hash = 23 * hash + VarianceFilter.GetHashCode();
+            hash = 23 * hash + Centroids.GetHashCode();
+            hash = 23 * hash + Partition.GetHashCode();
+            hash = 23 * hash + Merged.GetHashCode();
+            hash = 23 * hash + Subregions.GetHashCode();
+            
+            return hash;
+        }
+
         #endregion
     }
 }

--- a/src/Spectre.Algorithms/Spectre.Algorithms.csproj
+++ b/src/Spectre.Algorithms/Spectre.Algorithms.csproj
@@ -20,6 +20,7 @@
     <PlatformTarget>x64</PlatformTarget>
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
     <OutputPath>bin\x64\Release\</OutputPath>

--- a/src/Spectre.AlgorithmsCli.Tests/Methods/DivikConsistencyTests.h
+++ b/src/Spectre.AlgorithmsCli.Tests/Methods/DivikConsistencyTests.h
@@ -51,7 +51,7 @@ namespace Spectre::AlgorithmsCli::Tests::Methods
 			else
 				Assert::True(_equalOnTop, "Not equal on top.");
 		}
-		void OnWritten(System::Object ^sender, System::String ^e)
+		void OnWritten(System::Object^, System::String ^e)
 		{
 			System::Diagnostics::Debug::Write(e);
 		}

--- a/src/Spectre.AlgorithmsCli.Tests/Spectre.AlgorithmsCli.Tests.vcxproj
+++ b/src/Spectre.AlgorithmsCli.Tests/Spectre.AlgorithmsCli.Tests.vcxproj
@@ -97,11 +97,12 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
-      <WarningLevel>Level3</WarningLevel>
+      <WarningLevel>Level4</WarningLevel>
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <AdditionalOptions>/std:c++latest %(AdditionalOptions)</AdditionalOptions>
+      <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
     <Link>
       <AdditionalDependencies />
@@ -119,10 +120,11 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
-      <WarningLevel>Level3</WarningLevel>
+      <WarningLevel>Level4</WarningLevel>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
       <AdditionalOptions>/std:c++latest %(AdditionalOptions)</AdditionalOptions>
+      <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
     <Link>
       <AdditionalDependencies />

--- a/src/Spectre.AlgorithmsCli/Spectre.AlgorithmsCli.vcxproj
+++ b/src/Spectre.AlgorithmsCli/Spectre.AlgorithmsCli.vcxproj
@@ -52,11 +52,12 @@
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
-      <WarningLevel>Level3</WarningLevel>
+      <WarningLevel>Level4</WarningLevel>
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <PrecompiledHeader>Use</PrecompiledHeader>
       <AdditionalOptions>/std:c++latest %(AdditionalOptions)</AdditionalOptions>
+      <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
     <Link>
       <AdditionalDependencies />
@@ -64,10 +65,11 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
-      <WarningLevel>Level3</WarningLevel>
+      <WarningLevel>Level4</WarningLevel>
       <PreprocessorDefinitions>NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <PrecompiledHeader>Use</PrecompiledHeader>
       <AdditionalOptions>/std:c++latest %(AdditionalOptions)</AdditionalOptions>
+      <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
     <Link>
       <AdditionalDependencies />

--- a/src/Spectre.Data.Tests/Datasets/BasicTextDatasetTest.cs
+++ b/src/Spectre.Data.Tests/Datasets/BasicTextDatasetTest.cs
@@ -53,7 +53,7 @@ namespace Spectre.Data.Tests.Datasets
             double[] mz = {1.0, 2.0, 3.0};
             double[,] data = {{1, 2.1, 3.2}, {4, 5.1, 6.2}, {7, 8.1, 9.2}};
 
-            _dataset = new BasicTextDataset(mz, data);
+            _dataset = new BasicTextDataset(mz, data, null);
         }
 
         [Test]
@@ -97,15 +97,15 @@ namespace Spectre.Data.Tests.Datasets
             double[,] data = { { 1, 2.1, 3.2 } };
             int[,] coords = {{1, 2, 3}};
 
-            Assert.Throws<InvalidDataException>(() => { _dataset = new BasicTextDataset(null, data); },
+            Assert.Throws<InvalidDataException>(() => { _dataset = new BasicTextDataset(null, data, null); },
                 "Dataset accepted null m/z array.");
-            Assert.Throws<InvalidDataException>(() => { _dataset = new BasicTextDataset(mz, null); },
+            Assert.Throws<InvalidDataException>(() => { _dataset = new BasicTextDataset(mz, null, null); },
                 "Dataset accepted null intensity array.");
 
             mz = new[] { 1.0, 2.0, 3.0 };
             data = new[,] { { 1.0, 2.0 } };
 
-            Assert.Throws<InvalidDataException>(() => { _dataset = new BasicTextDataset(mz, data); },
+            Assert.Throws<InvalidDataException>(() => { _dataset = new BasicTextDataset(mz, data, null); },
                 "Dataset accepted raw data of different lengths.");
 
             data = new[,] { { 1, 1.1, 1.2 }, { 1, 1.1, 1.2 } };
@@ -154,7 +154,7 @@ namespace Spectre.Data.Tests.Datasets
         [Test]
         public void AppendFromRawDataTest()
         {
-            Assert.Throws<InvalidDataException>(() => { _dataset.AppendFromRawData(null); },
+            Assert.Throws<InvalidDataException>(() => { _dataset.AppendFromRawData(null, null); },
                 "Dataset accepted null raw data.");
 
             Assert.AreEqual(_dataset.SpectrumCount, 3,
@@ -162,7 +162,7 @@ namespace Spectre.Data.Tests.Datasets
 
             double[,] newData = {{0.1}};
 
-            Assert.Throws<InvalidDataException>(() => { _dataset.AppendFromRawData(newData); },
+            Assert.Throws<InvalidDataException>(() => { _dataset.AppendFromRawData(newData, null); },
                 "Dataset accepted raw data of different lengths.");
 
             Assert.AreEqual(_dataset.SpectrumCount, 3);

--- a/src/Spectre.Data.Tests/Spectre.Data.Tests.csproj
+++ b/src/Spectre.Data.Tests/Spectre.Data.Tests.csproj
@@ -24,6 +24,7 @@
     <PlatformTarget>x64</PlatformTarget>
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
     <OutputPath>bin\x64\Release\</OutputPath>

--- a/src/Spectre.Data/Datasets/BasicTextDataset.cs
+++ b/src/Spectre.Data/Datasets/BasicTextDataset.cs
@@ -75,7 +75,7 @@ namespace Spectre.Data.Datasets
         /// <param name="mz">Array of m/z values.</param>
         /// <param name="data">Array of intensity values.</param>
         /// <param name="coordinates">Array of spatial coordinates.</param>
-        public BasicTextDataset(double[] mz, double[,] data, int[,] coordinates = null)
+        public BasicTextDataset(double[] mz, double[,] data, int[,] coordinates)
         {
             CreateFromRawData(mz, data, coordinates);
         }
@@ -155,7 +155,7 @@ namespace Spectre.Data.Datasets
         /// </summary>
         /// <exception cref="InvalidDataException">Throws when the data is null or 
         /// the length of data is not matching the dataset length.</exception>
-        public void CreateFromRawData(double[] mz, double[,] data, int[,] coordinates = null)
+        public void CreateFromRawData(double[] mz, double[,] data, int[,] coordinates)
         {
             if (mz == null || data == null)
                 throw new InvalidDataException("The input data is null.");
@@ -228,7 +228,7 @@ namespace Spectre.Data.Datasets
         /// </summary>
         /// <exception cref="InvalidDataException">Throws when the data is null or 
         /// the length of data is not matching the dataset length.</exception>
-        public void AppendFromRawData(double[,] data, int[,] coordinates = null)
+        public void AppendFromRawData(double[,] data, int[,] coordinates)
         {
             if(data == null)
                 throw new InvalidDataException("The input data is null.");

--- a/src/Spectre.Data/Datasets/IDataset.cs
+++ b/src/Spectre.Data/Datasets/IDataset.cs
@@ -69,7 +69,7 @@ namespace Spectre.Data.Datasets
         /// <param name="mz">Array of m/z values.</param>
         /// <param name="data">Multidimensional array of intensity values.</param>
         /// <param name="coordinates">Spatial coordinates of input spectra.</param>
-        void CreateFromRawData(double[] mz, double[,] data, int[,] coordinates = null);
+        void CreateFromRawData(double[] mz, double[,] data, int[,] coordinates);
         /// <summary>
         /// Method for appending new data from file.
         /// </summary>
@@ -81,7 +81,7 @@ namespace Spectre.Data.Datasets
         /// </summary>
         /// <param name="data">Multidimensional array of intensity values.</param>
         /// <param name="coordinates">Spatial coordinates of input spectra.</param>
-        void AppendFromRawData(double[,] data, int[,] coordinates = null);
+        void AppendFromRawData(double[,] data, int[,] coordinates);
         #endregion
 
         #region Data access

--- a/src/Spectre.Data/Spectre.Data.csproj
+++ b/src/Spectre.Data/Spectre.Data.csproj
@@ -19,6 +19,7 @@
     <PlatformTarget>x64</PlatformTarget>
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
     <OutputPath>bin\x64\Release\</OutputPath>

--- a/src/Spectre.DivikWpfClient/Spectre.DivikWpfClient.csproj
+++ b/src/Spectre.DivikWpfClient/Spectre.DivikWpfClient.csproj
@@ -24,6 +24,7 @@
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
     <Prefer32Bit>true</Prefer32Bit>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
     <OutputPath>bin\x64\Release\</OutputPath>

--- a/src/Spectre.DivikWpfClient/ViewModel/MainPageVm.cs
+++ b/src/Spectre.DivikWpfClient/ViewModel/MainPageVm.cs
@@ -497,7 +497,7 @@ namespace Spectre.DivikWpfClient.ViewModel
                         MessageBox.Show("Divik was successfully cancelled.", "Cancelled!");
                         return;
                     }
-                    using (var consoleCapture = new ConsoleCaptureService())
+                    using (var consoleCapture = new ConsoleCaptureService(1000))
                     {
                         Log = string.Empty;
                         consoleCapture.Written += (sender, appended) => Log += appended;

--- a/src/Spectre.Mvvm.Tests/Spectre.Mvvm.Tests.csproj
+++ b/src/Spectre.Mvvm.Tests/Spectre.Mvvm.Tests.csproj
@@ -25,6 +25,7 @@
     <PlatformTarget>x64</PlatformTarget>
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
     <OutputPath>bin\x64\Release\</OutputPath>

--- a/src/Spectre.Mvvm/Spectre.Mvvm.csproj
+++ b/src/Spectre.Mvvm/Spectre.Mvvm.csproj
@@ -20,6 +20,7 @@
     <PlatformTarget>x64</PlatformTarget>
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
     <OutputPath>bin\x64\Release\</OutputPath>

--- a/src/Spectre.Service.Tests/Spectre.Service.Tests.csproj
+++ b/src/Spectre.Service.Tests/Spectre.Service.Tests.csproj
@@ -27,6 +27,7 @@
     <PlatformTarget>x64</PlatformTarget>
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
     <OutputPath>bin\x64\Release\</OutputPath>

--- a/src/Spectre.Service/ConsoleCaptureService.cs
+++ b/src/Spectre.Service/ConsoleCaptureService.cs
@@ -61,7 +61,7 @@ namespace Spectre.Service
         /// </summary>
         /// <param name="updateInterval">The update interval.</param>
         /// <exception cref="TooSmallUpdateIntervalException">updateInterval lower than MinimalReasonableUpdateInterval</exception>
-        public ConsoleCaptureService(double updateInterval=1000.0)
+        public ConsoleCaptureService(double updateInterval)
         {
             if (updateInterval < MinimalReasonableUpdateInterval)
                 throw new TooSmallUpdateIntervalException(updateInterval);

--- a/src/Spectre.Service/Spectre.Service.csproj
+++ b/src/Spectre.Service/Spectre.Service.csproj
@@ -20,6 +20,7 @@
     <PlatformTarget>x64</PlatformTarget>
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
     <OutputPath>bin\x64\Release\</OutputPath>

--- a/src/Spectre.Tests/Spectre.Tests.csproj
+++ b/src/Spectre.Tests/Spectre.Tests.csproj
@@ -25,6 +25,7 @@
     <PlatformTarget>x64</PlatformTarget>
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
     <OutputPath>bin\x64\Release\</OutputPath>

--- a/src/Spectre.libClustering.Tests/Spectre.libClustering.Tests.vcxproj
+++ b/src/Spectre.libClustering.Tests/Spectre.libClustering.Tests.vcxproj
@@ -53,11 +53,12 @@
     <ClCompile>
       <PrecompiledHeader>
       </PrecompiledHeader>
-      <WarningLevel>Level3</WarningLevel>
+      <WarningLevel>Level4</WarningLevel>
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>_DEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalOptions>/std:c++latest %(AdditionalOptions)</AdditionalOptions>
       <AdditionalIncludeDirectories>$(SolutionDir)Spectre.libClustering;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -66,7 +67,7 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
-      <WarningLevel>Level3</WarningLevel>
+      <WarningLevel>Level4</WarningLevel>
       <PrecompiledHeader>
       </PrecompiledHeader>
       <Optimization>MaxSpeed</Optimization>
@@ -75,6 +76,7 @@
       <PreprocessorDefinitions>NDEBUG;_CONSOLE;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalOptions>/std:c++latest %(AdditionalOptions)</AdditionalOptions>
       <AdditionalIncludeDirectories>$(SolutionDir)Spectre.libClustering;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/src/Spectre.libClustering/Spectre.libClustering.vcxproj
+++ b/src/Spectre.libClustering/Spectre.libClustering.vcxproj
@@ -58,10 +58,11 @@
     <ClCompile>
       <PrecompiledHeader>
       </PrecompiledHeader>
-      <WarningLevel>Level3</WarningLevel>
+      <WarningLevel>Level4</WarningLevel>
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>_DEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalOptions>/std:c++latest %(AdditionalOptions)</AdditionalOptions>
+      <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>
@@ -69,7 +70,7 @@
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
-      <WarningLevel>Level3</WarningLevel>
+      <WarningLevel>Level4</WarningLevel>
       <PrecompiledHeader>
       </PrecompiledHeader>
       <Optimization>MaxSpeed</Optimization>
@@ -77,6 +78,7 @@
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <PreprocessorDefinitions>NDEBUG;_LIB;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <AdditionalOptions>/std:c++latest %(AdditionalOptions)</AdditionalOptions>
+      <TreatWarningAsError>true</TreatWarningAsError>
     </ClCompile>
     <Link>
       <SubSystem>Windows</SubSystem>

--- a/src/Spectre/Spectre.csproj
+++ b/src/Spectre/Spectre.csproj
@@ -330,6 +330,7 @@
     <PlatformTarget>x64</PlatformTarget>
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release|x64'">
     <OutputPath>bin\</OutputPath>


### PR DESCRIPTION
Increases warning level and starts to treat warnings as errors.
Fixes all warning-generating places.

This should improve quality of code. Warning level and
treat warnings as errors should be enabled in any new project.