### PR TITLE
Read spectra by coords

### DIFF
--- a/src/Spectre.Tests/Controllers/SpectrumControllerTest.cs
+++ b/src/Spectre.Tests/Controllers/SpectrumControllerTest.cs
@@ -58,5 +58,40 @@ namespace Spectre.Tests.Controllers
                 actual: spectrum.Intensities.Count(),
                 message: "Intensities and Mz counts do not match.");
         }
+
+        /// <summary>
+        /// Tests reading of sample spectrum by valid coordinates.
+        /// </summary>
+        [Test]
+        public void TestReturnsSampleSpectrumByCoords()
+        {
+            var spectrum = _controller.Get(id: 1, x: 94, y: 31);
+            const double delta = 0.001;
+
+            Assert.NotNull(spectrum);
+            Assert.IsInstanceOf<Spectrum>(spectrum);
+
+            Assert.IsNotEmpty(spectrum.Intensities);
+            Assert.AreEqual(actual: spectrum.Intensities.First(), expected: 5487.54763657640, delta: delta);
+
+            Assert.IsNotEmpty(spectrum.Mz);
+            Assert.AreEqual(actual: spectrum.Mz.First(), expected: 799.796609809649, delta: delta);
+
+            Assert.AreEqual(
+                expected: spectrum.Mz.Count(),
+                actual: spectrum.Intensities.Count(),
+                message: "Intensities and Mz counts should match.");
+        }
+
+        /// <summary>
+        /// Tests reading of sample spectrum by invalid coordinates.
+        /// </summary>
+        [Test]
+        public void TestDoesNotReturnSampleSpectrumForInvalidCoords()
+        {
+            var spectrum = _controller.Get(id: 1, x: 0, y: 0);
+
+            Assert.Null(spectrum);
+        }
     }
 }

--- a/src/Spectre.Tests/Controllers/SpectrumControllerTest.cs
+++ b/src/Spectre.Tests/Controllers/SpectrumControllerTest.cs
@@ -17,11 +17,14 @@
    limitations under the License.
 */
 
+using System.Configuration;
+using System.IO;
 using System.Linq;
 using System.Net;
 using System.Web.Http;
 using NUnit.Framework;
 using Spectre.Controllers;
+using Spectre.Data.Datasets;
 using Spectre.Models.Msi;
 
 namespace Spectre.Tests.Controllers
@@ -68,9 +71,16 @@ namespace Spectre.Tests.Controllers
         [Test]
         public void TestThrows404ForInvalidSpectrum()
         {
+            var dataset = new BasicTextDataset(Path.Combine(ConfigurationManager.AppSettings["LocalDataDirectory"], "hnc1_tumor.txt"));
+            var preparationId = 1;
+            var spectrumId = dataset.SpectrumCount;
+
+            Assume.That(dataset.SpectrumCount, Is.GreaterThan(0), "Should be working on a non-empty dataset");
+            Assume.That(spectrumId, Is.GreaterThanOrEqualTo(dataset.SpectrumCount), "Should be a non-existent spectrum");
+
             try
             {
-                var spectrum = _controller.Get(id: 1, spectrumId: 999);
+                var spectrum = _controller.Get(id: preparationId, spectrumId: spectrumId);
                 Assert.Fail("Should throw for non-existent spectrum");
             }
             catch (HttpResponseException e)

--- a/src/Spectre.Tests/Controllers/SpectrumControllerTest.cs
+++ b/src/Spectre.Tests/Controllers/SpectrumControllerTest.cs
@@ -61,7 +61,10 @@ namespace Spectre.Tests.Controllers
             }
             catch (HttpResponseException e)
             {
-                Assert.AreEqual(actual: e.Response.StatusCode, expected: HttpStatusCode.NotFound);
+                Assert.AreEqual(
+                    actual: e.Response.StatusCode,
+                    expected: HttpStatusCode.NotFound,
+                    message: "Should respond with proper HTTP code");
             }
         }
 
@@ -85,7 +88,10 @@ namespace Spectre.Tests.Controllers
             }
             catch (HttpResponseException e)
             {
-                Assert.AreEqual(actual: e.Response.StatusCode, expected: HttpStatusCode.NotFound);
+                Assert.AreEqual(
+                    actual: e.Response.StatusCode,
+                    expected: HttpStatusCode.NotFound,
+                    message: "Should respond with proper HTTP code");
             }
         }
 
@@ -148,7 +154,10 @@ namespace Spectre.Tests.Controllers
             }
             catch (HttpResponseException e)
             {
-                Assert.AreEqual(actual: e.Response.StatusCode, expected: HttpStatusCode.NotFound);
+                Assert.AreEqual(
+                    actual: e.Response.StatusCode,
+                    expected: HttpStatusCode.NotFound,
+                    message: "Should respond with proper HTTP code");
             }
         }
     }

--- a/src/Spectre.Tests/Spectre.Tests.csproj
+++ b/src/Spectre.Tests/Spectre.Tests.csproj
@@ -123,6 +123,10 @@
       <Project>{9A886AEC-58DB-410D-91B9-C62E157501FA}</Project>
       <Name>Spectre.Algorithms</Name>
     </ProjectReference>
+    <ProjectReference Include="..\Spectre.Data\Spectre.Data.csproj">
+      <Project>{70C87AF7-3189-4F6C-AC85-93309CF7CFDC}</Project>
+      <Name>Spectre.Data</Name>
+    </ProjectReference>
     <ProjectReference Include="..\Spectre\Spectre.csproj">
       <Project>{0E4F265B-8702-4D70-AB70-AA566D7A2E40}</Project>
       <Name>Spectre</Name>

--- a/src/Spectre/Controllers/SpectrumController.cs
+++ b/src/Spectre/Controllers/SpectrumController.cs
@@ -16,8 +16,10 @@
 
 namespace Spectre.Controllers
 {
+    using System;
     using System.Configuration;
     using System.IO;
+    using System.Linq;
     using System.Web.Http;
     using System.Web.Http.Cors;
     using Spectre.Data.Datasets;
@@ -30,7 +32,7 @@ namespace Spectre.Controllers
     public class SpectrumController : ApiController
     {
         /// <summary>
-        /// Gets single spectrum of a specified preparation.
+        /// Gets single spectrum of a specified preparation by identifier.
         /// </summary>
         /// <param name="id">Preparation identifier.</param>
         /// <param name="spectrumId">Spectrum identifier.</param>
@@ -56,6 +58,44 @@ namespace Spectre.Controllers
                 Mz = mz,
                 X = coordinates.X,
                 Y = coordinates.Y
+            };
+        }
+
+        /// <summary>
+        /// Gets single spectrum of a specified preparation by spatial coordinates.
+        /// </summary>
+        /// <param name="id">Preparation identifier.</param>
+        /// <param name="x">Spectrum's X coordinate.</param>
+        /// <param name="y">Spectrum's Y coordinate.</param>
+        /// <returns>Spectrum</returns>
+        public Spectrum Get(int id, int x, int y)
+        {
+            if (id != 1)
+            {
+                return null;
+            }
+
+            var dataset = new BasicTextDataset(textFilePath: ConfigurationManager.AppSettings["LocalDataDirectory"] + Path.DirectorySeparatorChar + "hnc1_tumor.txt");
+
+            var spectrumId = dataset.SpatialCoordinates.ToList()
+                .FindIndex(sc => sc.X == x && sc.Y == y);
+
+            if (spectrumId == -1)
+            {
+                return null;
+            }
+
+            var mz = dataset.GetRawMzArray();
+            var intensities = dataset.GetRawIntensityArray(spectrumId);
+            var coordinates = dataset.GetSpatialCoordinates(spectrumId);
+
+            return new Spectrum()
+            {
+                Id = spectrumId,
+                Intensities = intensities,
+                Mz = mz,
+                X = x,
+                Y = y
             };
         }
     }

--- a/src/Spectre/Controllers/SpectrumController.cs
+++ b/src/Spectre/Controllers/SpectrumController.cs
@@ -20,6 +20,7 @@ namespace Spectre.Controllers
     using System.Configuration;
     using System.IO;
     using System.Linq;
+    using System.Net;
     using System.Web.Http;
     using System.Web.Http.Cors;
     using Spectre.Data.Datasets;
@@ -41,24 +42,31 @@ namespace Spectre.Controllers
         {
             if (id != 1)
             {
-                return null;
+                throw new HttpResponseException(HttpStatusCode.NotFound);
             }
 
             var dataset = new BasicTextDataset(textFilePath: ConfigurationManager.AppSettings["LocalDataDirectory"] + Path.DirectorySeparatorChar + "hnc1_tumor.txt");
 
             var mz = dataset.GetRawMzArray();
 
-            var intensities = dataset.GetRawIntensityArray(spectrumId);
-            var coordinates = dataset.GetSpatialCoordinates(spectrumId);
-
-            return new Spectrum()
+            try
             {
-                Id = spectrumId,
-                Intensities = intensities,
-                Mz = mz,
-                X = coordinates.X,
-                Y = coordinates.Y
-            };
+                var intensities = dataset.GetRawIntensityArray(spectrumId);
+                var coordinates = dataset.GetSpatialCoordinates(spectrumId);
+
+                return new Spectrum()
+                {
+                    Id = spectrumId,
+                    Intensities = intensities,
+                    Mz = mz,
+                    X = coordinates.X,
+                    Y = coordinates.Y
+                };
+            }
+            catch (ArgumentOutOfRangeException)
+            {
+                throw new HttpResponseException(HttpStatusCode.NotFound);
+            }
         }
 
         /// <summary>
@@ -72,7 +80,7 @@ namespace Spectre.Controllers
         {
             if (id != 1)
             {
-                return null;
+                throw new HttpResponseException(HttpStatusCode.NotFound);
             }
 
             var dataset = new BasicTextDataset(textFilePath: ConfigurationManager.AppSettings["LocalDataDirectory"] + Path.DirectorySeparatorChar + "hnc1_tumor.txt");
@@ -82,7 +90,7 @@ namespace Spectre.Controllers
 
             if (spectrumId == -1)
             {
-                return null;
+                throw new HttpResponseException(HttpStatusCode.NotFound);
             }
 
             var mz = dataset.GetRawMzArray();


### PR DESCRIPTION
- Allow querying for spectra using X, Y coordinates.
- Refactor existing code to throw HTTP 404 when queried for non-existent preparation/spectrum.