### PR TITLE
Preparation spatial coordinate ranges

### DIFF
--- a/src/Spectre.Tests/Models/RangeTest.cs
+++ b/src/Spectre.Tests/Models/RangeTest.cs
@@ -1,0 +1,61 @@
+﻿/*
+ * RangeTest.cs
+ * Tests for Range model.
+ *
+   Copyright 2017 Maciej Gamrat
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+using System;
+using System.Linq;
+using NUnit.Framework;
+using Spectre.Controllers;
+using Spectre.Models.Msi;
+
+namespace Spectre.Tests.Models
+{
+    /// <summary>
+    /// Tests for Range model.
+    /// </summary>
+    [TestFixture]
+    public class RangeTest
+    {
+        /// <summary>
+        /// Tests getters.
+        /// </summary>
+        [Test]
+        public void TestRangeGetters()
+        {
+            var range = new Range(3, 5);
+            Assert.AreEqual(range.Min, 3);
+            Assert.AreEqual(range.Max, 5);
+        }
+
+        /// <summary>
+        /// Tests getters.
+        /// </summary>
+        [Test]
+        public void TestRangeSetters()
+        {
+            var range = new Range(0, 0);
+            Assert.AreEqual(range.Min, 0);
+            Assert.AreEqual(range.Max, 0);
+
+            range.Min = 3;
+            range.Max = 5;
+            Assert.AreEqual(range.Min, 3);
+            Assert.AreEqual(range.Max, 5);
+        }
+    }
+}

--- a/src/Spectre.Tests/Spectre.Tests.csproj
+++ b/src/Spectre.Tests/Spectre.Tests.csproj
@@ -110,6 +110,7 @@
     <Compile Include="Controllers\HeatmapControllerTest.cs" />
     <Compile Include="Controllers\PreparationsControllerTest.cs" />
     <Compile Include="Controllers\SpectrumControllerTest.cs" />
+    <Compile Include="Models\RangeTest.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Spectre/Controllers/PreparationsController.cs
+++ b/src/Spectre/Controllers/PreparationsController.cs
@@ -37,7 +37,12 @@ namespace Spectre.Controllers
         {
             return new[]
             {
-                new Preparation(name: "Head & neck cancer, patient 1, tumor region only", id: 1, spectraNumber: 997)
+                new Preparation(
+                    id: 1,
+                    name: "Head & neck cancer, patient 1, tumor region only",
+                    spectraNumber: 997,
+                    xRange: new Range(63, 106),
+                    yRange: new Range(1, 109))
             };
         }
 
@@ -49,7 +54,12 @@ namespace Spectre.Controllers
         public Preparation Get(int id)
         {
             return id == 1
-                ? new Preparation(name: "Head & neck cancer, patient 1, tumor region only", id: 1, spectraNumber: 997)
+                ? new Preparation(
+                    id: 1,
+                    name: "Head & neck cancer, patient 1, tumor region only",
+                    spectraNumber: 997,
+                    xRange: new Range(63, 106),
+                    yRange: new Range(1, 109))
                 : null;
         }
     }

--- a/src/Spectre/Models/Msi/Preparation.cs
+++ b/src/Spectre/Models/Msi/Preparation.cs
@@ -33,11 +33,15 @@ namespace Spectre.Models.Msi
         /// <param name="name">The name.</param>
         /// <param name="id">The identifier.</param>
         /// <param name="spectraNumber">Number of all spectra in preparation.</param>
-        public Preparation(string name, int id, int spectraNumber)
+        /// <param name="xRange">Pair of minimum &amp; maximum coordinate along X axis.</param>
+        /// <param name="yRange">Pair of minimum &amp; maximum coordinate along Y axis.</param>
+        public Preparation(string name, int id, int spectraNumber, Range xRange, Range yRange)
         {
             Name = name;
             Id = id;
             SpectraNumber = spectraNumber;
+            XRange = xRange;
+            YRange = yRange;
         }
 
         /// <summary>
@@ -66,6 +70,24 @@ namespace Spectre.Models.Msi
         /// </value>
         [DataMember]
         public int SpectraNumber { get; private set; }
+
+        /// <summary>
+        /// Specifies the inclusive range of spectrum coordinates along X axis.
+        /// </summary>
+        /// <value>
+        /// Tuple containing minimal &amp; maximal coordinate values.
+        /// </value>
+        [DataMember]
+        public Range XRange { get; private set; }
+
+        /// <summary>
+        /// Specifies the inclusive range of spectrum coordinates along Y axis.
+        /// </summary>
+        /// <value>
+        /// Tuple containing minimal &amp; maximal coordinate values.
+        /// </value>
+        [DataMember]
+        public Range YRange { get; private set; }
 
         /// <summary>
         /// Gets the number of chanelIds.

--- a/src/Spectre/Models/Msi/Range.cs
+++ b/src/Spectre/Models/Msi/Range.cs
@@ -1,0 +1,59 @@
+﻿/*
+ * Range.cs
+ * Class representing value range.
+ *
+   Copyright 2017 Maciej Gamrat
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+using System.Runtime.Serialization;
+
+namespace Spectre.Models.Msi
+{
+    /// <summary>
+    /// Represents a value range.
+    /// </summary>
+    [DataContract]
+    public class Range
+    {
+        /// <summary>
+        /// Initializes a new instance of the <see cref="Range"/> class.
+        /// </summary>
+        /// <param name="min">Minimal value.</param>
+        /// <param name="max">Maximal value.</param>
+        public Range(int min, int max)
+        {
+            Min = min;
+            Max = max;
+        }
+
+        /// <summary>
+        /// Stores range minimum.
+        /// </summary>
+        /// <value>
+        /// Range minimum.
+        /// </value>
+        [DataMember]
+        public int Min { get; set; }
+
+        /// <summary>
+        /// Stores range maximum.
+        /// </summary>
+        /// <value>
+        /// Range maximum.
+        /// </value>
+        [DataMember]
+        public int Max { get; set; }
+    }
+}

--- a/src/Spectre/Spectre.csproj
+++ b/src/Spectre/Spectre.csproj
@@ -239,6 +239,7 @@
     <Compile Include="Models\Msi\Heatmap.cs" />
     <Compile Include="Models\Msi\DivikResult.cs" />
     <Compile Include="Models\Msi\Preparation.cs" />
+    <Compile Include="Models\Msi\Range.cs" />
     <Compile Include="Models\Msi\Spectrum.cs" />
     <Compile Include="Models\RegisterBindingModel.cs" />
     <Compile Include="Models\RegisterExternalBindingModel.cs" />


### PR DESCRIPTION
Adds coordinate range info to preparations API. Ranges are _inclusive_.

```json
{
  "Id": 1,
  "Name": "Head & neck cancer, patient 1, tumor region only",
  "SpectraNumber": 997,
  "XRange": {
    "Min": 63,
    "Max": 106
  },
  "YRange": {
    "Min": 1,
    "Max": 109
  },
  "ChanelIdAvailableNumber": 0
}
```