### PR TITLE
Create compose

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ script:
 after_success:
 - |
   if [ $CONFIGURATION = "prod" ]; then
-      docker build -t spectreteam/spectre:latest -t spectreteam/spectre:beta -t spectreteam:$VERSION -t spectreteam:$VERSION-beta -t spectreteam:$VERSION-alpha .
+      docker build -t spectreteam/spectre:latest -t spectreteam/spectre:beta -t spectreteam/spectre:$VERSION -t spectreteam/spectre:$VERSION-beta -t spectreteam/spectre:$VERSION-alpha .
       docker images
       if [ $TRAVIS_PULL_REQUEST = "false" ]; then
           if [ $TRAVIS_BRANCH = "master" ]; then

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,6 @@
+version: '2'
+
+services:
+
+volumes:
+    data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -58,6 +58,15 @@ services:
         volumes:
           - data:/data
 
+    celery-flower:
+        image: spectreteam/spectre-analysis:1.0.0
+        command: celery -A spectre_analyses flower --loglevel=info --port=80 --address=0.0.0.0
+        depends_on:
+          - rabbitmq
+          - postgresql
+        ports:
+          - "2004:80"
+
 volumes:
     data:
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,5 +28,13 @@ services:
         volumes:
             - data:/data
 
+    rabbitmq:
+        image: rabbitmq:3.7.3-management
+        hostname: 'rabbitmq'
+        restart: always
+        environment:
+            RABBITMQ_DEFAULT_USER: guest
+            RABBITMQ_DEFAULT_PASS: guest
+
 volumes:
     data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,5 +36,18 @@ services:
             RABBITMQ_DEFAULT_USER: guest
             RABBITMQ_DEFAULT_PASS: guest
 
+    postgresql:
+        image: postgres:10.2-alpine
+        hostname: 'postgresql'
+        restart: always
+        environment:
+            POSTGRES_USER: guest
+            POSTGRES_PASSWORD: guest
+            POSTGRES_DB: celery
+        volumes:
+            - celery:/var/lib/postgresql/data
+
 volumes:
     data:
+
+    celery:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,15 @@ version: '2'
 
 services:
 
+    client:
+        restart: always
+        image: spectreteam/spectre:beta
+        ports:
+            - "80:80"
+        depends_on:
+            - visualization-api
+            - upload-api
+
     visualization-api:
         restart: always
         image: spectreteam/spectre-visualization:1.0.0.24

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,5 +20,13 @@ services:
         volumes:
             - data:/data
 
+    upload-api:
+        restart: always
+        image: spectreteam/spectre-upload:1.0.2.139
+        ports:
+            - "2002:80"
+        volumes:
+            - data:/data
+
 volumes:
     data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,5 +2,14 @@ version: '2'
 
 services:
 
+    visualization-api:
+        restart: always
+        image: spectreteam/spectre-visualization:1.0.0.24
+        hostname: 'visualization'
+        ports:
+            - "2001:80"
+        volumes:
+            - data:/data
+
 volumes:
     data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -67,6 +67,14 @@ services:
         ports:
           - "2004:80"
 
+    divik-worker:
+        image: spectreteam/divik-worker:1.0.0
+        depends_on:
+          - rabbitmq
+          - postgresql
+        volumes:
+          - data:/data
+
 volumes:
     data:
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,6 +47,17 @@ services:
         volumes:
             - celery:/var/lib/postgresql/data
 
+    analysis-api:
+        image: spectreteam/spectre-analysis:1.0.0
+        ports:
+          - "2003:80"
+        depends_on:
+          - rabbitmq
+          - postgresql
+          - visualization-api
+        volumes:
+          - data:/data
+
 volumes:
     data:
 

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -47,6 +47,7 @@ module.exports = function (config) {
         properties: {},
         xmlVersion: null
     },
+    browserNoActivityTimeout: 30000,
     port: 9876,
     colors: true,
     logLevel: config.LOG_INFO,


### PR DESCRIPTION
Fixes the problem with tests' timeouts and introduces `docker-compose.yml` with specification of current stable services stack. In future, we will replace `client` version to use `latest` instead of `beta` or any more specific version. Right now it corresponds to actual content of our image repository.